### PR TITLE
Phase 1: project bootstrap (module, Makefile, CI/CD)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - P2
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      test-deps-patch:
+        patterns:
+          - "github.com/stretchr/testify"
+          - "github.com/cucumber/godog"
+          - "go.uber.org/goleak"
+        update-types:
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - ci/cd
+      - P2
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,119 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Format check
+        run: make fmt-check
+      - name: Vet
+        run: make vet
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.5.0
+      - name: Module tidy check
+        run: make tidy-check
+
+  test:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Unit tests
+        run: make test
+      - name: BDD tests
+        run: make test-bdd
+      - name: Coverage
+        if: matrix.os == 'ubuntu-latest'
+        run: make coverage
+      - name: Upload coverage
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: go build ./...
+
+  security:
+    name: Security scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  release-check:
+    name: GoReleaser config check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Vet
         run: make vet
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.5.0
       - name: Module tidy check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.5.0
+          version: v2.11.4
+          install-mode: goinstall
       - name: Module tidy check
         run: make tidy-check
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Enable auto-merge for patch-level test-dependency updates
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Inspect Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash) for test-dep patches only
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' &&
+          (steps.meta.outputs.dependency-group == 'test-deps-patch' ||
+           steps.meta.outputs.package-ecosystem == 'github-actions')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.9.0). Must not exist yet; workflow creates it."
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run — build and validate without publishing or tagging."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify quality gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Run quality gate
+        run: make check
+
+  tag:
+    name: Create tag
+    needs: verify
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate tag format
+        run: |
+          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Tag must match vMAJOR.MINOR.PATCH[-prerelease]"
+            exit 1
+          fi
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ inputs.tag }}" -m "Release ${{ inputs.tag }}"
+          git push origin "${{ inputs.tag }}"
+
+  goreleaser:
+    name: GoReleaser
+    needs: [verify, tag]
+    if: always() && needs.verify.result == 'success' && (needs.tag.result == 'success' || needs.tag.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Dry-run GoReleaser
+        if: inputs.dry_run == true
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+      - name: Publish GoReleaser
+        if: inputs.dry_run != true
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  proxy-warm:
+    name: Warm Go module proxy
+    needs: goreleaser
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Request module from proxy (with retry)
+        run: |
+          tag="${{ inputs.tag }}"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -sSfL "https://proxy.golang.org/github.com/axonops/mask/@v/${tag}.info" | tee /dev/stderr; then
+              exit 0
+            fi
+            echo "proxy not ready, retry ${attempt}/6 in 15s"
+            sleep 15
+          done
+          echo "proxy did not index ${tag} after 90s"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ coverage.*
 *.coverprofile
 profile.cov
 
+# GoReleaser snapshot output
+dist/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
@@ -30,3 +33,64 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# General
+.DS_Store
+.localized
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[]
+
+# Resource forks
+._*
+
+# Files and directories that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.com.apple.timemachine.supported
+.PKInstallSandboxManager
+.PKInstallSandboxManager-SystemSoftware
+.hotfiles.btree
+.vol
+.file
+.disk_label*
+lost+found
+.HFS+ Private Directory Data[]
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Mac OS 6 to 9
+Desktop DB
+Desktop DF
+TheFindByContentFolder
+TheVolumeSettingsFolder
+.FBCIndex
+.FBCSemaphoreFile
+.FBCLockFolder
+
+# Quota system
+.quota.group
+.quota.user
+.quota.ops.group
+.quota.ops.user
+
+# TimeMachine
+Backups.backupdb
+.MobileBackups
+.MobileBackups.trash
+MobileBackups.trash
+tmbootpicker.efi
+
+CLAUDE.md
+.claude/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,71 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - gocyclo
+    - gocritic
+    - revive
+    - unconvert
+    - unparam
+    - bodyclose
+    - goconst
+    - prealloc
+    - nolintlint
+    - copyloopvar
+  settings:
+    gocyclo:
+      min-complexity: 10
+    misspell:
+      locale: UK
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+        - name: var-naming
+        - name: package-comments
+        - name: if-return
+        - name: error-return
+        - name: error-naming
+        - name: error-strings
+        - name: errorf
+        - name: unused-parameter
+          disabled: true
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - gocritic
+          - unparam
+          - goconst
+      - path: tests/bdd/
+        linters:
+          - gocyclo
+          - gocritic
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/axonops/mask
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,70 @@
+version: 2
+
+project_name: mask
+
+builds:
+  - skip: true
+
+archives:
+  - id: source
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+      - SECURITY.md
+      - CONTRIBUTING.md
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Documentation
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: Performance
+      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      order: 3
+    - title: Refactors
+      regexp: '^.*?refactor(\([[:word:]]+\))??!?:.+$'
+      order: 4
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: axonops
+    name: mask
+  prerelease: auto
+  draft: false
+  mode: replace
+  header: |
+    ## mask {{ .Tag }}
+
+    Pure-function Go string-masking library. Zero runtime dependencies.
+
+    See [CHANGELOG.md](./CHANGELOG.md) for full release notes.
+  footer: |
+    ---
+
+    **Full diff:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/axonops/mask/compare/{{ .PreviousTag }}...{{ .Tag }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to `github.com/axonops/mask` are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Initial public release in progress. No versioned releases yet.
+
+### Added
+
+- Project scaffolding: Go module, Makefile, `.golangci.yml`, GoReleaser configuration.
+- Continuous integration workflow covering format check, vet, lint, unit and BDD tests, coverage, module tidy, security scan, and cross-platform builds (`linux/amd64`, `darwin/arm64`, `windows/amd64`).
+- CI-only release workflow with dry-run support — no local tagging permitted.
+- Dependabot configuration for weekly Go module and GitHub Actions updates.
+- `CONTRIBUTING.md` and `SECURITY.md`.
+
+[Unreleased]: https://github.com/axonops/mask/compare/HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to mask
+
+Thank you for your interest in contributing to `github.com/axonops/mask`. This document covers the expectations for code, tests, documentation, and release discipline.
+
+## Ground rules
+
+- **Zero runtime dependencies.** The library MUST remain stdlib-only. PRs that add a runtime dependency will not be merged.
+- **Correctness first.** Every masking rule, every primitive, and every edge case is covered by both unit and BDD tests. If a change cannot be tested, it cannot land.
+- **Fail closed.** Masking rules never return the original unmasked value on parse failure.
+
+## Branching
+
+- `main` is always green and always buildable.
+- Feature work: `feature/<short-name>` branched from `main`.
+- Bug fixes: `fix/<short-name>` branched from `main`.
+- Never commit directly to `main`.
+
+## Commits
+
+Conventional Commits are mandatory:
+
+```
+<type>(<scope>): <subject> (#<issue>)
+
+<body>
+```
+
+**Types:** `feat`, `fix`, `test`, `docs`, `chore`, `refactor`, `perf`.
+
+**Rules:**
+
+1. Subject line: imperative mood, lowercase, no period, ≤ 72 chars.
+2. Every commit MUST reference the GitHub issue it addresses: `feat: add iban masking rule (#12)`.
+3. Body is optional but MUST explain *why*, not *what*.
+4. Never mention AI tooling (Claude, Copilot, GPT, LLM, Anthropic) anywhere in a commit message.
+5. One logical change per commit. Use rebase, not merge commits.
+
+## Pull requests
+
+Every PR MUST:
+
+1. Reference the issue it closes (`Closes #N`).
+2. Include unit tests AND BDD scenarios for every new or changed masking rule.
+3. Include a benchmark for any rule on the hot path.
+4. Pass `make check` locally before pushing.
+5. Keep `go.mod` and `go.sum` tidy (`go mod tidy` clean).
+6. Maintain coverage at 90% or higher.
+
+CI runs the same gates as `make check`. If CI fails on your PR, fix the root cause — do not add suppressions or `//nolint` directives without an issue reference.
+
+## Testing
+
+- Unit tests live beside the code in external (`package mask_test`) black-box style.
+- BDD tests live under `tests/bdd/`. Feature files in `tests/bdd/features/`, step definitions in `tests/bdd/steps/`.
+- Every masking rule and every primitive has at least one `Scenario Outline` with `Examples` covering canonical, formatted, malformed, empty, and (where applicable) unicode inputs.
+- Benchmarks live in `*_bench_test.go` files and call `b.ReportAllocs()`.
+
+See [`CLAUDE.md`][claude-md] (not in this repo — developer-local) and the `docs/v0.9.0-requirements.md` spec for the authoritative testing requirements.
+
+## Code standards
+
+- Google Go Style Guide baseline.
+- Functions over ~40 lines: split them.
+- Cyclomatic complexity > 10: refactor before merge.
+- Errors wrapped with `%w` and context.
+- No `Get` prefix on accessors. Acronyms preserve case (`URL`, `PAN`, `IBAN`).
+- Apache 2.0 licence header on every `.go` file.
+
+## Releases are CI-only
+
+**Never tag locally. Never run `goreleaser release` locally.**
+
+The release process is:
+
+1. Update `CHANGELOG.md` and any version references in a PR to `main`.
+2. After merge, trigger the `Release` workflow via `workflow_dispatch` with the target tag, OR publish a GitHub Release.
+3. CI validates the quality gate, creates the tag, and runs GoReleaser.
+
+Any local tagging attempt is a policy violation. The `devops` review agent treats local tagging in workflows or docs as a BLOCKING issue.
+
+### Branch protection
+
+The `main` branch is protected. The protection rules require:
+
+- Pull request review before merge.
+- Status checks: `CI` must pass.
+- Linear history (no merge commits).
+- No force pushes.
+- Only administrators may override, and overrides are logged.
+
+## Security
+
+See [`SECURITY.md`](./SECURITY.md) for vulnerability disclosure.
+
+## Licence
+
+By contributing, you agree that your contributions will be licensed under the [Apache Licence 2.0](./LICENSE).
+
+[claude-md]: CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,93 @@
+.DEFAULT_GOAL := help
+SHELL := bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+GO           ?= go
+GOBIN        ?= $(shell $(GO) env GOPATH)/bin
+GOLANGCI     ?= $(GOBIN)/golangci-lint
+GOIMPORTS    ?= $(GOBIN)/goimports
+GOVULNCHECK  ?= $(GOBIN)/govulncheck
+GORELEASER   ?= goreleaser
+
+GO_FILES     := $(shell find . -type f -name '*.go' -not -path './.git/*' 2>/dev/null)
+PKG          := ./...
+BDD_PKG      := ./tests/bdd/...
+COVER_OUT    := coverage.out
+COVER_HTML   := coverage.html
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.PHONY: check
+check: fmt-check vet lint tidy-check test test-bdd coverage security ## Run the full quality gate (mirrors CI)
+
+.PHONY: test
+test: ## Run unit tests with race detector
+	$(GO) test -race -count=1 $(PKG)
+
+.PHONY: test-bdd
+test-bdd: ## Run BDD tests
+	@if [ -d tests/bdd ]; then \
+		$(GO) test -race -count=1 -tags bdd $(BDD_PKG); \
+	else \
+		echo "tests/bdd not present yet — skipping BDD run"; \
+	fi
+
+.PHONY: lint
+lint: ## Run golangci-lint
+	$(GOLANGCI) run $(PKG)
+
+.PHONY: vet
+vet: ## Run go vet
+	$(GO) vet $(PKG)
+
+.PHONY: fmt
+fmt: ## Auto-format Go source files
+	$(GO) fmt $(PKG)
+	@if command -v $(GOIMPORTS) >/dev/null 2>&1; then $(GOIMPORTS) -w $(GO_FILES); fi
+
+.PHONY: fmt-check
+fmt-check: ## Fail if any Go file is unformatted
+	@out=$$(gofmt -s -l .); if [ -n "$$out" ]; then echo "gofmt diff:"; echo "$$out"; exit 1; fi
+	@if command -v $(GOIMPORTS) >/dev/null 2>&1; then out=$$($(GOIMPORTS) -l .); if [ -n "$$out" ]; then echo "goimports diff:"; echo "$$out"; exit 1; fi; fi
+
+.PHONY: bench
+bench: ## Run benchmarks
+	$(GO) test -bench=. -benchmem -run=^$$ $(PKG)
+
+.PHONY: coverage
+coverage: ## Generate coverage profile and HTML report
+	$(GO) test -race -coverprofile=$(COVER_OUT) -covermode=atomic $(PKG)
+	$(GO) tool cover -func=$(COVER_OUT) | tail -1
+	$(GO) tool cover -html=$(COVER_OUT) -o $(COVER_HTML)
+
+.PHONY: tidy
+tidy: ## Run go mod tidy
+	$(GO) mod tidy
+
+.PHONY: tidy-check
+tidy-check: ## Fail if go mod tidy would modify go.mod or go.sum
+	@cp go.mod go.mod.bak
+	@[ -f go.sum ] && cp go.sum go.sum.bak || true
+	@$(GO) mod tidy
+	@if ! diff -q go.mod go.mod.bak >/dev/null; then mv go.mod.bak go.mod; [ -f go.sum.bak ] && mv go.sum.bak go.sum || true; echo "go.mod drift — run 'make tidy'"; exit 1; fi
+	@if [ -f go.sum ] && [ -f go.sum.bak ] && ! diff -q go.sum go.sum.bak >/dev/null; then mv go.sum.bak go.sum; mv go.mod.bak go.mod; echo "go.sum drift — run 'make tidy'"; exit 1; fi
+	@rm -f go.mod.bak go.sum.bak
+
+.PHONY: security
+security: ## Run govulncheck
+	@if command -v $(GOVULNCHECK) >/dev/null 2>&1; then \
+		$(GOVULNCHECK) $(PKG); \
+	else \
+		echo "govulncheck not installed — skipping (install: go install golang.org/x/vuln/cmd/govulncheck@latest)"; \
+	fi
+
+.PHONY: release-check
+release-check: ## Validate GoReleaser config without releasing
+	$(GORELEASER) check
+
+.PHONY: clean
+clean: ## Remove generated test and coverage artefacts
+	$(GO) clean -testcache
+	rm -f $(COVER_OUT) $(COVER_HTML)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+The `mask` library is currently in pre-release (`v0.x`). Only the most recent `v0.x` minor release receives security fixes until `v1.0.0` stabilises the API.
+
+| Version | Supported |
+|---------|-----------|
+| `v0.9.x` | Yes |
+| Older | No |
+
+## Threat model
+
+`github.com/axonops/mask` is a pure-function string-masking library. Consumers embed it to redact personally identifying information, payment card data, and protected health information before logging, displaying, or persisting values.
+
+**In scope:**
+
+- Correctness of masking rules against the spec in `docs/v0.9.0-requirements.md`.
+- Fail-closed behaviour: the library MUST NEVER return the original unmasked value when a rule cannot parse its input.
+- No leakage of the unmasked input through error messages, panics, or logs.
+- Unicode correctness: no byte-level splitting that could produce partially masked output.
+- Thread safety under the documented contract (`Register` at init, `Apply` concurrent thereafter).
+- Use of `crypto/sha256` for `deterministic_hash` — never MD5 or SHA-1.
+
+**Out of scope:**
+
+- Guaranteeing anonymisation. `deterministic_hash` is **pseudonymisation**, not anonymisation — same input always produces the same output, so the hash remains a linkable identifier.
+- Validating that callers use the correct rule for their data. The library masks; it does not detect.
+- Protecting against memory disclosure through unrelated channels (process dumps, swap, etc.).
+- Side-channel timing analysis. Masking is not a cryptographic primitive.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** through GitHub Security Advisories:
+
+https://github.com/axonops/mask/security/advisories/new
+
+Include:
+
+- A description of the issue and its impact.
+- Steps to reproduce (input, expected output, actual output).
+- The library version and Go version you observed it with.
+- Any suggested mitigation.
+
+We aim to acknowledge reports within three working days and to issue a fix or mitigation guidance within 30 days for confirmed high-severity issues.
+
+Please do **not** file a public GitHub issue for vulnerabilities.
+
+## Disclosure policy
+
+Once a fix is released, the advisory is published on GitHub and the fix is referenced in the `CHANGELOG.md` entry under the relevant release.

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mask is a pure-function string-masking library with composable
+// primitives and a rich catalogue of built-in domain rules for redacting
+// personally identifying information, payment card data, and protected
+// health information.
+//
+// This file is a placeholder during Phase 1 bootstrap. The full package
+// documentation lands with the core API in Phase 2 (#2).
+package mask

--- a/docs/v0.9.0-requirements.md
+++ b/docs/v0.9.0-requirements.md
@@ -1,0 +1,824 @@
+# mask v0.9.0 — Requirements
+
+## Overview
+
+`github.com/axonops/mask` is a standalone Go string-masking library. Its job is `string → masked string` with a rich set of built-in rules, composable utility primitives, and support for custom masking rules.
+
+This document is the authoritative source for masking rule definitions, naming conventions, preservation semantics, and the starter catalog. All implementation, documentation, and testing must conform to this specification.
+
+## Design Principles
+
+### 1. Separation of Detection and Masking
+
+A masking rule defines what to preserve and what to redact, even when the input string is malformed. The library does NOT validate input — it masks it. Optional validation may be layered on top for stricter modes or test fixtures, but the core masking function always returns a result, never an error for built-in rules.
+
+### 2. Explicit, Composable Preservation Semantics
+
+Generic primitives (`full_redact`, `keep_first_n`, `keep_last_n`, `keep_first_last`, `replace_regex`, `deterministic_hash`, etc.) are the foundation. Domain-specific rules are thin wrappers over these primitives with format-aware parsing. This separation means new domain rules are trivial to add.
+
+### 3. Format Preservation
+
+Preserve formatting where it materially helps operators or users recognise the data type, unless a regulation suggests stronger concealment. For example, PAN masking preserves separators (dashes, spaces) between digit groups. HIPAA de-identification guidance is more conservative for directly identifying healthcare fields.
+
+### 4. Fail Closed
+
+When a masking rule cannot parse the input (e.g., `payment_card_pan` receives a string that isn't a card number), it falls back to a stronger mask (full redact or `same_length_mask`), never returns the original unmasked value. A predictable fallback policy is easier to test and safer than throwing errors.
+
+### 5. Jurisdiction-Qualified Naming
+
+Use `<jurisdiction>_<artifact>` for country-specific identifiers: `us_ssn`, `ca_sin`, `uk_nino`, `in_aadhaar`. Use `<standard>_<artifact>` for standard formats: `payment_card_pan`, `iban`. Use generic fallback labels only when there is no materially different country behaviour.
+
+The naming convention is lowercase `snake_case` throughout. This ensures consistency, code-generation safety, and readability in configuration files.
+
+### 6. Identifier Rules vs Content Rules
+
+Identifier rules mask a single atomic value: `us_ssn`, `iban`, `email_address`. Content rules mask sensitive subcomponents within a structured string: `url`, `database_dsn`, `connection_string`, `jwt_token`. Content rules must parse the structure and target only the sensitive parts.
+
+## API Specification
+
+### Package-Level Functions (Global Registry)
+
+```go
+// Apply masks value using the named built-in or registered rule.
+// Returns the masked string. If the rule is unknown, returns a
+// full-redact result — never the original value.
+func Apply(rule string, value string) string
+
+// Register adds a custom masking rule to the global registry.
+// Returns an error if the rule name is already registered.
+// Must be called during program initialisation, before concurrent
+// use of Apply. This is the same contract as database/sql.Register.
+func Register(name string, fn func(string) string) error
+
+// SetMaskChar sets the default mask character for the global registry.
+// Default is '*'.
+func SetMaskChar(c rune)
+```
+
+### Per-Instance API
+
+```go
+// New creates a new Masker instance with all built-in rules pre-registered.
+// Options configure instance-specific behaviour.
+func New(opts ...Option) *Masker
+
+// Option configures a Masker instance.
+type Option func(*Masker)
+
+// WithMaskChar sets the mask character for this instance.
+func WithMaskChar(c rune) Option
+
+// Masker provides an isolated masking registry.
+type Masker struct { ... }
+
+// Apply masks value using the named rule from this instance's registry.
+func (m *Masker) Apply(rule string, value string) string
+
+// Register adds a custom masking rule to this instance's registry.
+func (m *Masker) Register(name string, fn func(string) string) error
+```
+
+### Thread Safety Contract
+
+`Register` (both global and per-instance) must not be called concurrently with `Apply`. Call `Register` during program initialisation. After initialisation, the registry is read-only and `Apply` is safe for concurrent use. All built-in maskers are stateless pure functions. This is the same contract as `database/sql.Register`.
+
+### Mask Character
+
+The default mask character is `*` (U+002A). It can be overridden globally via `SetMaskChar` or per-instance via `WithMaskChar`. All built-in rules must use the configured mask character, not hardcode `*`.
+
+## Naming Model
+
+### Convention
+
+All rule labels use lowercase `snake_case`. Country-specific rules use `<country_code>_<artifact>` prefix. Standard-specific rules use descriptive domain names.
+
+### Label Changes from Common Conventions
+
+| Common label | This library's label | Rationale |
+|---|---|---|
+| `ssn` | `us_ssn` | SSN is US-specific; avoids conflation with other national IDs |
+| `sin` | `ca_sin` | Canadian Social Insurance Number; jurisdiction-qualified |
+| `nino` | `uk_nino` | UK National Insurance Number; jurisdiction-qualified |
+| `sort_code` | `uk_sort_code` | UK-specific banking identifier |
+| `routing_number` | `us_aba_routing_number` | US ABA routing number; jurisdiction-qualified |
+| `name` | `person_name` | Avoids ambiguity with other "name" concepts |
+| `first_name` | `given_name` | International terminology |
+| `last_name` | `family_name` | International terminology |
+| `drivers_licence` | `driver_license_number` | Normalised spelling, explicit "number" |
+| `credit_card` | `payment_card_pan` | PCI DSS terminology |
+| `cvv` | `payment_card_cvv` | Scoped to payment card domain |
+| `medical_record` | `medical_record_number` | HIPAA terminology |
+| `health_plan_id` | `health_plan_beneficiary_id` | HIPAA terminology |
+| `jwt` | `jwt_token` | Explicit that this is a token rule |
+| `dsn` | `database_dsn` | Distinguishes from other DSN meanings |
+| `phone` | `phone_number` | Explicit |
+| `coordinates` | `geo_coordinates` | Scoped to geography domain |
+
+Generic labels `generic_national_id`, `tax_identifier`, `mobile_phone_number`, and `monetary_amount` are documented as **fallback policies** — users should prefer the most specific country-aware rule available.
+
+## Core Rule Schema
+
+Each masking rule is documented with:
+
+| Field | Description |
+|---|---|
+| `name` | Canonical label used in `mask.Apply` |
+| `aliases` | Alternative names that resolve to this rule (if any) |
+| `category` | identity, financial, health, technology, telecom, utility |
+| `jurisdiction` | Country/region, or "global" |
+| `preserve` | What segments are kept visible (e.g., `first=6,last=4`) |
+| `replacement` | How masked characters are rendered |
+| `preserve_separators` | Whether formatting characters (dashes, spaces, dots) are kept |
+| `fallback_behavior` | What happens when input cannot be parsed |
+| `examples` | At least 3 input/output pairs |
+| `regulatory_context` | PCI DSS, HIPAA, GDPR references where applicable |
+
+---
+
+## Masking Rule Catalog
+
+### Personal and Identity
+
+#### `email_address`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** First character of local part; full domain (including TLD); `@` separator
+- **Mask:** Remaining local part characters
+- **Preserve separators:** Yes (`@`, `.`)
+- **Fallback:** If no `@` found, apply `same_length_mask`
+- **Regulatory context:** HIPAA identifier; GDPR personal data
+- **Examples:**
+  - `alice@example.com` → `a****@example.com`
+  - `bob.smith+work@company.co.uk` → `b*************@company.co.uk`
+  - `x@y.com` → `x@y.com` (single-char local part — nothing to mask)
+  - `not-an-email` → `*************` (fallback)
+
+#### `person_name`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** First grapheme of each whitespace-separated token; spaces, hyphens, apostrophes between tokens
+- **Mask:** Remaining graphemes of each token
+- **Note:** Must use grapheme-aware logic, not byte count, for international names
+- **Fallback:** `same_length_mask`
+- **Examples:**
+  - `John Doe` → `J*** D**`
+  - `María García-López` → `M**** G*****-L****`
+  - `佐藤太郎` → `佐*太*` (two-token CJK name)
+
+#### `given_name`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** First grapheme only
+- **Examples:**
+  - `Alice` → `A****`
+  - `María` → `M****`
+
+#### `family_name`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** First grapheme only
+- **Examples:**
+  - `Smith` → `S****`
+  - `O'Brien` → `O******`
+
+#### `street_address`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** House/building number if leading digits detected; trailing street type if recognised (St, Road, Ave, etc.)
+- **Mask:** Street name body
+- **Fallback:** `same_length_mask`
+- **Regulatory context:** HIPAA Safe Harbor treats street address elements as identifiers
+- **Examples:**
+  - `42 Wallaby Way` → `42 ******* Way`
+  - `1600 Pennsylvania Avenue NW` → `1600 ************ Avenue NW`
+
+#### `date_of_birth`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** Year only by default; full redact in strict mode
+- **Mask:** Month and day
+- **Regulatory context:** HIPAA Safe Harbor treats date elements below year as identifying
+- **Examples:**
+  - `1985-03-15` → `1985-**-**`
+  - `15/03/1985` → `**/****/1985`
+  - `March 15, 1985` → `***** **, 1985`
+
+#### `username`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** First 2 graphemes
+- **Examples:**
+  - `johndoe42` → `jo********`
+  - `admin` → `ad***`
+
+#### `passport_number`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** Issuing-country prefix if present (first 2 chars); last 2-4 chars
+- **Mask:** Middle characters
+- **Note:** Passport formats vary widely; do not overclaim format validation
+- **Examples:**
+  - `GB1234567` → `GB*****67`
+  - `123456789` → `*****6789`
+
+#### `driver_license_number`
+- **Category:** Identity
+- **Jurisdiction:** Global
+- **Preserve:** First 2 and last 2-4 characters; separators
+- **Note:** Formats are highly local; treat as semi-structured strings
+- **Examples:**
+  - `DL-1234-5678` → `DL-****-5678`
+  - `SMITH901015JN9AA` → `SM**********9AA`
+
+#### `generic_national_id`
+- **Category:** Identity
+- **Jurisdiction:** Global (fallback)
+- **Preserve:** First 2 and last 2 characters
+- **Note:** Use sparingly — prefer country-specific rules. National IDs vary widely.
+- **Examples:**
+  - `AB123456CD` → `AB******CD`
+
+#### `tax_identifier`
+- **Category:** Identity
+- **Jurisdiction:** Global (fallback)
+- **Preserve:** Last 3-4 characters; known country prefix or checksum suffix if format requires
+- **Note:** Global TIN formats vary significantly
+- **Examples:**
+  - `12-3456789` → `**-***6789`
+
+#### `us_ssn`
+- **Category:** Identity
+- **Jurisdiction:** United States
+- **Preserve:** Last 4 digits; canonical `AAA-GG-SSSS` separators if present
+- **Regulatory context:** US-specific; governed by SSA regulations
+- **Examples:**
+  - `123-45-6789` → `***-**-6789`
+  - `123456789` → `*****6789`
+
+#### `ca_sin`
+- **Category:** Identity
+- **Jurisdiction:** Canada
+- **Preserve:** Last 3 digits; formatting if present
+- **Examples:**
+  - `123-456-789` → `***-***-789`
+  - `123456789` → `******789`
+
+#### `uk_nino`
+- **Category:** Identity
+- **Jurisdiction:** United Kingdom
+- **Preserve:** Prefix letters (first 2) and suffix letter (last 1); mask numeric body
+- **Note:** UK NINO has structured alpha/numeric components: `AB123456C`
+- **Examples:**
+  - `AB123456C` → `AB******C`
+  - `AB 12 34 56 C` → `AB ** ** ** C`
+
+#### `in_aadhaar`
+- **Category:** Identity
+- **Jurisdiction:** India
+- **Preserve:** Last 4 digits only; grouping if present
+- **Note:** India explicitly offers "masked Aadhaar" showing only last 4 digits
+- **Examples:**
+  - `1234 5678 9012` → `**** **** 9012`
+  - `123456789012` → `********9012`
+
+#### `in_pan`
+- **Category:** Identity
+- **Jurisdiction:** India
+- **Preserve:** First 3 characters and last 1-2 characters
+- **Note:** Indian PAN is a common tax identifier format: `ABCDE1234F`
+- **Examples:**
+  - `ABCDE1234F` → `ABC*****4F`
+
+#### `au_medicare_number`
+- **Category:** Identity
+- **Jurisdiction:** Australia
+- **Preserve:** Last 3-4 digits
+- **Examples:**
+  - `2123 45670 1` → `**** ****0 1`
+
+#### `sg_nric_fin`
+- **Category:** Identity
+- **Jurisdiction:** Singapore
+- **Preserve:** Prefix letter and suffix letter; mask numeric body
+- **Note:** NRIC/FIN has structured leading and trailing letters: `S1234567A`
+- **Examples:**
+  - `S1234567A` → `S*******A`
+
+#### `br_cpf`
+- **Category:** Identity
+- **Jurisdiction:** Brazil
+- **Preserve:** Last 2-4 digits; punctuation if present
+- **Note:** CPF is a widely used personal taxpayer identifier: `123.456.789-09`
+- **Examples:**
+  - `123.456.789-09` → `***.***.***-09`
+  - `12345678909` → `*******8909`
+
+#### `br_cnpj`
+- **Category:** Identity
+- **Jurisdiction:** Brazil
+- **Preserve:** Last 4 digits; punctuation if present
+- **Note:** CNPJ is the business taxpayer identifier: `12.345.678/0001-95`
+- **Examples:**
+  - `12.345.678/0001-95` → `**.***.***/****-95`
+
+#### `mx_curp`
+- **Category:** Identity
+- **Jurisdiction:** Mexico
+- **Preserve:** First 4 and last 2-4 characters
+- **Note:** CURP is a structured personal identifier (18 characters)
+- **Examples:**
+  - `GAPA850101HDFRRL09` → `GAPA**********L09`
+
+#### `mx_rfc`
+- **Category:** Identity
+- **Jurisdiction:** Mexico
+- **Preserve:** First 3-4 and last 2-3 characters
+- **Note:** RFC is the Mexican tax identifier
+- **Examples:**
+  - `GAPA8501014T3` → `GAP*******4T3`
+
+#### `cn_resident_id`
+- **Category:** Identity
+- **Jurisdiction:** China
+- **Preserve:** First 6 (region code) and last 4 characters
+- **Note:** PRC resident identity card numbers are structured 18-digit identifiers
+- **Examples:**
+  - `110101199003074578` → `110101********4578`
+
+#### `za_national_id`
+- **Category:** Identity
+- **Jurisdiction:** South Africa
+- **Preserve:** First 6 (date of birth) and last 4 characters
+- **Examples:**
+  - `8501015009087` → `850101***9087`
+
+#### `es_dni_nif_nie`
+- **Category:** Identity
+- **Jurisdiction:** Spain
+- **Preserve:** Leading letter/prefix and trailing control character; mask numeric body
+- **Note:** Spain uses several related personal/tax identifier schemes
+- **Examples:**
+  - `12345678Z` → `********Z`
+  - `X1234567L` → `X*******L`
+
+---
+
+### Financial
+
+#### `payment_card_pan`
+- **Category:** Financial
+- **Jurisdiction:** Global (PCI DSS)
+- **Preserve:** First 6 digits (BIN/IIN) and last 4 digits; separators (dashes, spaces)
+- **Regulatory context:** PCI DSS commonly limits displayed PAN to first 6 and last 4 at most
+- **Fallback:** If string is not 13-19 digits (after stripping separators), apply `same_length_mask`
+- **Examples:**
+  - `4111222233334444` → `411122******4444`
+  - `4111-2222-3333-4444` → `4111-22**-****-4444`
+  - `371449635398431` → `371449*****8431` (AMEX 15-digit)
+
+#### `payment_card_pan_first6`
+- **Category:** Financial
+- **Jurisdiction:** Global (PCI DSS)
+- **Preserve:** First 6 digits only; separators
+- **Examples:**
+  - `4111222233334444` → `411122**********`
+  - `4111-2222-3333-4444` → `4111-22**-****-****`
+
+#### `payment_card_pan_last4`
+- **Category:** Financial
+- **Jurisdiction:** Global (PCI DSS)
+- **Preserve:** Last 4 digits only; separators
+- **Examples:**
+  - `4111222233334444` → `************4444`
+  - `4111-2222-3333-4444` → `****-****-****-4444`
+
+#### `payment_card_cvv`
+- **Category:** Financial
+- **Jurisdiction:** Global (PCI DSS)
+- **Preserve:** Nothing — full redact with fixed replacement
+- **Regulatory context:** Sensitive Authentication Data; must not be retained after authorisation
+- **Examples:**
+  - `123` → `***`
+  - `1234` → `****`
+
+#### `payment_card_pin`
+- **Category:** Financial
+- **Jurisdiction:** Global
+- **Preserve:** Nothing — full redact with fixed replacement
+- **Examples:**
+  - `1234` → `****`
+  - `123456` → `******`
+
+#### `bank_account_number`
+- **Category:** Financial
+- **Jurisdiction:** Global
+- **Preserve:** Last 4 digits; separators if present
+- **Examples:**
+  - `12345678` → `****5678`
+  - `1234-5678-9012` → `****-****-9012`
+
+#### `uk_sort_code`
+- **Category:** Financial
+- **Jurisdiction:** United Kingdom
+- **Preserve:** First 2 digits; separators
+- **Examples:**
+  - `12-34-56` → `12-**-**`
+  - `123456` → `12****`
+
+#### `us_aba_routing_number`
+- **Category:** Financial
+- **Jurisdiction:** United States
+- **Preserve:** Last 4 digits
+- **Examples:**
+  - `021000021` → `*****0021`
+
+#### `iban`
+- **Category:** Financial
+- **Jurisdiction:** Global (ISO 13616)
+- **Preserve:** Country code (first 2), check digits (next 2), and last 4; grouping spaces if present
+- **Examples:**
+  - `GB82WEST12345698765432` → `GB82***************5432`
+  - `GB82 WEST 1234 5698 7654 32` → `GB82 **** **** **** ***4 32`
+  - `DE89370400440532013000` → `DE89***************3000`
+
+#### `swift_bic`
+- **Category:** Financial
+- **Jurisdiction:** Global (ISO 9362)
+- **Preserve:** Bank code (first 4); optionally country code (next 2)
+- **Examples:**
+  - `BARCGB2L` → `BARC****`
+  - `DEUTDEFF500` → `DEUT*******`
+
+#### `monetary_amount`
+- **Category:** Financial
+- **Jurisdiction:** Global
+- **Preserve:** Nothing by default — full redact
+- **Note:** Amount masking is contextual and policy-driven. Default is full redact. Consumers may register custom rules for range bucketing or precision reduction.
+- **Examples:**
+  - `$1,234.56` → `[REDACTED]`
+  - `€99.99` → `[REDACTED]`
+
+---
+
+### Healthcare
+
+#### `medical_record_number`
+- **Category:** Health
+- **Jurisdiction:** Global (HIPAA)
+- **Preserve:** Last 4 characters in operational mode; full redact in strict mode
+- **Regulatory context:** HIPAA identifier
+- **Examples:**
+  - `MRN-123456789` → `MRN-*****6789`
+  - `123456789` → `*****6789`
+
+#### `health_plan_beneficiary_id`
+- **Category:** Health
+- **Jurisdiction:** Global (HIPAA)
+- **Preserve:** Last 4 characters; full redact in strict mode
+- **Regulatory context:** Explicitly listed HIPAA terminology
+- **Examples:**
+  - `HPB-987654321` → `HPB-*****4321`
+
+#### `medical_device_identifier`
+- **Category:** Health
+- **Jurisdiction:** Global (HIPAA)
+- **Preserve:** Last 4 characters
+- **Regulatory context:** Device identifiers and serial numbers are HIPAA identifiers when tied to individuals
+- **Examples:**
+  - `DEV-SN-12345678` → `DEV-SN-****5678`
+
+#### `diagnosis_code`
+- **Category:** Health
+- **Jurisdiction:** Global
+- **Preserve:** Nothing — full redact by default
+- **Note:** Diagnosis codes are clinical data. Full redact is safer but not always necessary. ICD codes are not inherently direct identifiers.
+- **Examples:**
+  - `J45.20` → `[REDACTED]`
+  - `E11.9` → `[REDACTED]`
+
+#### `prescription_text`
+- **Category:** Health
+- **Jurisdiction:** Global
+- **Preserve:** Nothing — full redact by default
+- **Note:** Prescription contents may expose conditions and should be treated conservatively
+- **Examples:**
+  - `Metformin 500mg twice daily` → `[REDACTED]`
+
+---
+
+### Technology and Infrastructure
+
+#### `ipv4_address`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** First 2 octets by default; mask last 2 octets
+- **Regulatory context:** IP addresses are HIPAA identifiers and personal data in many privacy regimes
+- **Examples:**
+  - `192.168.1.42` → `192.168.*.*`
+  - `10.0.0.1` → `10.0.*.*`
+
+#### `ipv6_address`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** Routed prefix (first 4 hextets); mask interface identifier (last 4 hextets)
+- **Examples:**
+  - `2001:0db8:85a3:0000:0000:8a2e:0370:7334` → `2001:0db8:85a3:0000:****:****:****:****`
+  - `fe80::1` → `fe80::****`
+
+#### `mac_address`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** OUI (first 3 octets); mask device-specific last 3 octets
+- **Note:** Preserves vendor recognition while hiding device identity
+- **Examples:**
+  - `AA:BB:CC:DD:EE:FF` → `AA:BB:CC:**:**:**`
+  - `AA-BB-CC-DD-EE-FF` → `AA-BB-CC-**-**-**`
+
+#### `hostname`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** First label only; mask remaining labels
+- **Examples:**
+  - `web-01.prod.example.com` → `web-01.*.*.***`
+  - `db-master` → `db-master`
+
+#### `url`
+- **Category:** Technology (Content Rule)
+- **Jurisdiction:** Global
+- **Preserve:** Scheme, host, and optional port; mask path segments, query values, and fragment
+- **Note:** URL subcomponents often contain secrets or identifiers. Parse with `net/url` and mask components.
+- **Examples:**
+  - `https://example.com/users/42?token=abc` → `https://example.com/*****/****?token=****`
+  - `http://localhost:8080/api/v1` → `http://localhost:8080/****/***`
+
+#### `url_credentials`
+- **Category:** Technology (Content Rule)
+- **Jurisdiction:** Global
+- **Preserve:** Scheme and host; fully redact userinfo
+- **Examples:**
+  - `https://admin:s3cret@db.example.com/mydb` → `https://****:****@db.example.com/mydb`
+
+#### `api_key`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** Short prefix (first 4 chars) and last 4 chars; support provider-aware prefixes like `sk_`, `pk_`
+- **Examples:**
+  - `sk_live_abc123def456ghi789` → `sk_l****...****i789`
+  - `AKIAIOSFODNN7EXAMPLE` → `AKIA************MPLE`
+
+#### `jwt_token`
+- **Category:** Technology (Content Rule)
+- **Jurisdiction:** Global
+- **Preserve:** Token type indicator and optionally first few chars of header segment; redact payload and signature entirely
+- **Note:** JWT payload is only base64url-encoded, not encrypted; exposing it leaks claims
+- **Examples:**
+  - `eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U` → `eyJh****.****.****.`
+
+#### `bearer_token`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** Auth scheme and at most first 6-8 chars of token; redact rest
+- **Examples:**
+  - `Bearer eyJhbGciOiJIUzI1NiJ9.xxx.yyy` → `Bearer eyJhbG****...`
+  - `Bearer abc123def456` → `Bearer abc123****...`
+
+#### `password`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** Nothing — fixed replacement independent of source length
+- **Note:** Length leakage can be undesirable for secrets
+- **Examples:**
+  - `MyP@ssw0rd!` → `********`
+  - `x` → `********`
+
+#### `private_key_pem`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** Nothing — full redact with constant marker
+- **Note:** Never partially reveal key material
+- **Examples:**
+  - `-----BEGIN RSA PRIVATE KEY-----\nMIIE...` → `[REDACTED]`
+
+#### `connection_string`
+- **Category:** Technology (Content Rule)
+- **Jurisdiction:** Global
+- **Preserve:** Protocol, host, port, database/service name; redact username, password, token, secret query params
+- **Examples:**
+  - `postgresql://admin:s3cret@db.example.com:5432/myapp` → `postgresql://****:****@db.example.com:5432/myapp`
+  - `mongodb+srv://user:pass@cluster.mongodb.net/db` → `mongodb+srv://****:****@cluster.mongodb.net/db`
+
+#### `database_dsn`
+- **Category:** Technology (Content Rule)
+- **Jurisdiction:** Global
+- **Preserve:** Driver/network/location; redact password and secret params
+- **Examples:**
+  - `user:password@tcp(localhost:3306)/dbname` → `****:****@tcp(localhost:3306)/dbname`
+
+#### `uuid`
+- **Category:** Technology
+- **Jurisdiction:** Global
+- **Preserve:** First 8 and last 4 characters; mask middle groups
+- **Note:** UUIDs can still be unique identifiers even when partially masked. Do not call this anonymisation.
+- **Examples:**
+  - `550e8400-e29b-41d4-a716-446655440000` → `550e8400-****-****-****-********0000`
+
+---
+
+### Telecommunications and Location
+
+#### `phone_number`
+- **Category:** Telecom
+- **Jurisdiction:** Global
+- **Preserve:** Country code (if present) and last 2-4 digits; mask middle digits; preserve separators
+- **Note:** Normalise conceptually to E.164 when possible; handle international numbers with country-code awareness
+- **Examples:**
+  - `+44 7911 123456` → `+44 **** **3456`
+  - `(555) 123-4567` → `(***) ***-4567`
+  - `+1-800-555-0199` → `+1-***-***-0199`
+
+#### `mobile_phone_number`
+- **Category:** Telecom
+- **Jurisdiction:** Global
+- **Preserve:** Same as `phone_number` unless a local jurisdiction needs separate semantics
+- **Note:** Prefer one international abstraction unless business rules differ
+- **Examples:**
+  - `07911 123456` → `07*** ***456`
+
+#### `imei`
+- **Category:** Telecom
+- **Jurisdiction:** Global
+- **Preserve:** Last 4 digits; optionally preserve TAC (first 8) in telecom operations mode
+- **Examples:**
+  - `353456789012345` → `***********2345`
+
+#### `imsi`
+- **Category:** Telecom
+- **Jurisdiction:** Global
+- **Preserve:** MCC/MNC prefix (first 5-6 digits) and last 2-4; mask subscriber body
+- **Examples:**
+  - `310260123456789` → `31026*******6789`
+
+#### `msisdn`
+- **Category:** Telecom
+- **Jurisdiction:** Global
+- **Preserve:** Country code and last 4; mask middle
+- **Examples:**
+  - `447911123456` → `44*****3456`
+
+#### `postal_code`
+- **Category:** Location
+- **Jurisdiction:** Global (country-aware precision reduction)
+- **Preserve:** Country-aware: keep outward code in UK, first 3 digits in US ZIP
+- **Regulatory context:** HIPAA Safe Harbor has specific rules for geographic subdivisions
+- **Examples:**
+  - `SW1A 2AA` → `SW1A ***` (UK — keep outward code)
+  - `94103` → `941**` (US — keep first 3)
+  - `M5V 2T6` → `M5V ***` (Canada — keep FSA)
+
+#### `geo_latitude`
+- **Category:** Location
+- **Jurisdiction:** Global
+- **Preserve:** Reduced precision (2-3 decimal places by default)
+- **Examples:**
+  - `37.7749295` → `37.77***`
+  - `-33.8688197` → `-33.87***`
+
+#### `geo_longitude`
+- **Category:** Location
+- **Jurisdiction:** Global
+- **Preserve:** Reduced precision (2-3 decimal places by default)
+- **Examples:**
+  - `-122.4194155` → `-122.42***`
+
+#### `geo_coordinates`
+- **Category:** Location
+- **Jurisdiction:** Global
+- **Preserve:** Reduced both coordinates together; preserve pair formatting
+- **Note:** Coordinate pairs should be masked atomically
+- **Examples:**
+  - `37.7749,-122.4194` → `37.77***,-122.42***`
+
+---
+
+### Utility Primitives
+
+These are the composable building blocks. All domain rules above are thin wrappers over these primitives.
+
+#### `full_redact`
+- Replace entire value with a fixed string: `[REDACTED]`
+
+#### `same_length_mask`
+- Replace every character with the mask character, preserving length
+- Example: `Hello` → `*****`
+
+#### `keep_first_n`
+- Preserve first N characters, mask the rest
+- Parameter: `n` (integer)
+- Example (n=4): `SensitiveData` → `Sens*********`
+
+#### `keep_last_n`
+- Preserve last N characters, mask the rest
+- Parameter: `n` (integer)
+- Example (n=4): `SensitiveData` → `*********Data`
+
+#### `keep_first_last`
+- Preserve first N and last M characters, mask the middle
+- Parameters: `first` (integer), `last` (integer)
+- Example (first=4, last=4): `SensitiveData123` → `Sens********a123`
+
+#### `preserve_delimiters`
+- Mask characters but preserve delimiter/separator characters (configurable)
+- Used internally by domain rules for format preservation
+
+#### `replace_regex`
+- Apply a regex substitution to mask matching portions
+- Parameters: `pattern` (regex), `replacement` (string)
+- Note: Regex must be compiled at init time, not per-call
+
+#### `truncate_visible`
+- Show first N characters with no mask characters appended
+- Parameter: `n` (integer)
+- Example (n=4): `SensitiveData` → `Sens`
+
+#### `deterministic_hash`
+- Replace value with a truncated SHA-256 hex digest
+- Default: first 16 hex chars prefixed with `sha256:`
+- Example: `alice@example.com` → `sha256:a1b2c3d4e5f6a7b8`
+- Note: This is pseudonymisation, NOT anonymisation. Same input always produces same output, enabling correlation without exposure.
+- Security: Must use `crypto/sha256`, never MD5 or SHA1
+
+#### `nullify`
+- Replace value with empty string
+
+#### `fixed_replacement`
+- Replace value with a caller-specified fixed string regardless of input
+- Parameter: `replacement` (string)
+- Example (replacement="N/A"): `anything` → `N/A`
+
+#### `reduce_precision`
+- For numeric strings, reduce decimal precision
+- Parameter: `decimals` (integer)
+- Example (decimals=2): `37.7749295` → `37.77***`
+
+---
+
+## Regulatory Anchors
+
+### PCI DSS
+The clearest anchor for payment-card display rules. Supports the common first-6/last-4 display limit for PAN. Treats CVV and PIN as Sensitive Authentication Data that must never be retained after authorisation.
+
+### HIPAA Safe Harbor
+The clearest anchor for healthcare-oriented direct identifiers. The 18 HIPAA identifiers include: names, geographic subdivisions smaller than a state (with limited exceptions), date elements below year, phone numbers, fax numbers, email addresses, Social Security numbers, medical record numbers, health plan beneficiary numbers, account numbers, certificate/license numbers, vehicle identifiers/serial numbers, device identifiers/serial numbers, web URLs, IP addresses, biometric identifiers, full-face photographs, and any other unique identifying number, characteristic, or code.
+
+### GDPR
+Does not prescribe a universal character-level masking formula, but strongly supports data minimisation and risk-reduction measures. Country-specific identifiers and partial masking are best framed as privacy engineering controls, not legal safe harbours. The library should document masking as a configurable protective transformation, not as a guarantee of anonymisation.
+
+---
+
+## Implementation Guidance
+
+### Two-Layer Architecture
+
+1. **Rule layer** — each rule declares its normalisation and preservation behaviour
+2. **Executor layer** — applies Unicode-aware masking, preserves chosen delimiters, and fails closed to a stronger mask when parsing fails
+
+### Unicode Awareness
+
+- Use `[]rune` or grapheme-aware iteration for character counting
+- Never assume 1 character = 1 byte
+- `person_name`, `given_name`, `family_name` must handle CJK, Arabic, Devanagari, etc.
+- Test with international input for every rule that processes text (not just numbers)
+
+### Testing Requirements
+
+Each masking rule must have fixtures covering:
+1. **Canonical input** — standard, well-formatted value
+2. **Formatted input** — same value with different separator style
+3. **Malformed input** — value that doesn't match expected format (triggers fallback)
+4. **Already-masked input** — value containing mask characters
+5. **Unicode input** — international characters where applicable
+6. **Empty input** — empty string
+7. **Very long input** — 1000+ character string
+
+For content/container rules (URL, DSN, JWT), additionally test:
+8. **Parseable input** — well-formed structure
+9. **Non-parseable input** — malformed structure (triggers fallback)
+
+### CI/CD Requirements
+
+- **CI workflow** runs on every PR and push to main: format check, vet, lint, test (unit + BDD), coverage, module hygiene, security scan
+- **Release workflow** triggered only through CI — never local tags
+- **GoReleaser** for release automation
+- **Dependabot** for dependency updates
+- Cross-platform build verification: `linux/amd64`, `darwin/arm64`, `windows/amd64`
+
+---
+
+## Module Specification
+
+- **Module:** `github.com/axonops/mask`
+- **Go version:** 1.26+
+- **Runtime dependencies:** zero (stdlib only)
+- **Test dependencies:** `testify`, `godog`, `goleak`
+- **License:** Apache 2.0
+- **Structure:** Single module, single package, no sub-modules, no binaries

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/axonops/mask
+
+go 1.26


### PR DESCRIPTION
## Summary

- Initialises the Go 1.26 module and wires up the full quality toolchain (Makefile, golangci-lint v2, goimports, govulncheck).
- Adds CI workflow running format check, vet, lint, unit + BDD tests, coverage, module tidy, security scan, and a cross-platform build matrix (linux/amd64, darwin/arm64, windows/amd64).
- Adds CI-only release workflow triggered by `workflow_dispatch`, with `tag` and `dry_run` inputs, per-job permission scoping, and a proxy-warm step with retry.
- Adds GoReleaser in library mode (source archives), Dependabot for gomod + github-actions with a patch-level auto-merge workflow for test dependencies.
- Seeds `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md` (Keep a Changelog format), and a minimal placeholder `doc.go` that Phase 2 replaces.

Closes #1.

## Test plan

- [x] `make check` passes locally (fmt, vet, lint, tidy, unit, BDD-skipped, coverage, govulncheck).
- [x] `goreleaser check` passes.
- [x] `goreleaser release --snapshot --clean` produces source archives.
- [x] `make help` renders every target.
- [ ] CI on this PR is green across all matrix entries (to verify after push).
- [ ] Dependabot auto-merge workflow triggers on the first eligible PR (observed in follow-up).