### PR TITLE
Phase 3: utility primitives + configurable deterministic hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,57 @@ permissions:
   contents: read
 
 jobs:
+  bdd-strict-mode-guard:
+    name: BDD strict mode guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify every godog TestSuite sets Strict=true
+        run: |
+          set -euo pipefail
+
+          # Locate godog entry files: any .go file that constructs a
+          # godog.TestSuite{}. We require each one to carry an explicit
+          # `Strict: true` option. Silently running with strict mode off
+          # lets unimplemented steps slip through — the single most common
+          # BDD failure mode and something the project has been burned by.
+          mapfile -t files < <(grep -rln "godog.TestSuite" --include='*.go' tests || true)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No godog.TestSuite entry found — is the BDD suite still present?"
+            exit 1
+          fi
+
+          failed=0
+          for f in "${files[@]}"; do
+            if grep -qE "Strict:\s*false" "$f"; then
+              echo "::error file=$f::BDD strict mode is disabled (Strict: false). Strict mode is mandatory; see feedback_bdd_strict_mode memory."
+              failed=1
+              continue
+            fi
+            if ! grep -qE "Strict:\s*true" "$f"; then
+              echo "::error file=$f::BDD entry file does not set Strict: true explicitly. The flag MUST be present — do not rely on defaults."
+              failed=1
+              continue
+            fi
+            echo "$f: OK (Strict: true)"
+          done
+
+          # Forbid any env-var or build-tag escape hatch that would disable
+          # strict mode conditionally.
+          if grep -rnE "Strict:\s*[A-Za-z_][A-Za-z0-9_]*" --include='*.go' tests | grep -vE "Strict:\s*true" ; then
+            echo "::error::A BDD entry file appears to gate Strict on a variable — strict mode MUST be a compile-time constant true."
+            failed=1
+          fi
+
+          # Flag suspicious skip/pending patterns in feature files.
+          if grep -rnE "@(skip|wip|pending|todo)\b" --include='*.feature' tests ; then
+            echo "::error::Feature files contain @skip / @wip / @pending / @todo tags. These are incompatible with strict mode and must be removed before merge."
+            failed=1
+          fi
+
+          exit "$failed"
+
   attribution-guard:
     name: No AI attribution
     runs-on: ubuntu-latest

--- a/bench.txt
+++ b/bench.txt
@@ -1,0 +1,37 @@
+# Baseline benchmarks for github.com/axonops/mask
+#
+# Regenerate this file via:
+#   go test -bench=. -benchmem -run=^$ . > bench.txt
+#
+# Captured: Phase 3 (utility primitives landing — issue #3)
+# Host: Apple M2 / darwin-arm64 / Go 1.26
+#
+# Intended use: benchstat golden — future CI runs benchstat bench.txt new.txt
+# and fails on regressions. Integration of that CI job is tracked separately.
+#
+goos: darwin
+goarch: arm64
+pkg: github.com/axonops/mask
+cpu: Apple M2
+BenchmarkFullRedact-8                        	1000000000	         0.3307 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSameLengthMask_1000-8               	  365866	      3122 ns/op	    1024 B/op	       1 allocs/op
+BenchmarkKeepFirstN_16-8                     	22014561	        53.94 ns/op	      16 B/op	       1 allocs/op
+BenchmarkKeepFirstN_1000-8                   	  382159	      3257 ns/op	    1024 B/op	       1 allocs/op
+BenchmarkKeepLastN_16-8                      	18178408	        68.03 ns/op	      16 B/op	       1 allocs/op
+BenchmarkKeepLastN_1000-8                    	  323806	      3692 ns/op	    1024 B/op	       1 allocs/op
+BenchmarkKeepFirstLast_16-8                  	20918738	        58.03 ns/op	      16 B/op	       1 allocs/op
+BenchmarkKeepFirstLast_1000-8                	  299095	      3972 ns/op	    1024 B/op	       1 allocs/op
+BenchmarkTruncateVisible_16-8                	277720428	         4.371 ns/op	       0 B/op	       0 allocs/op
+BenchmarkTruncateVisible_1000-8              	276125895	         4.320 ns/op	       0 B/op	       0 allocs/op
+BenchmarkPreserveDelimiters_Email-8          	12818646	        93.47 ns/op	      24 B/op	       1 allocs/op
+BenchmarkPreserveDelimitersFunc_Email-8      	10956343	       109.1 ns/op	      24 B/op	       1 allocs/op
+BenchmarkReplaceRegexFunc_1000-8             	   44373	     25269 ns/op	    4635 B/op	      11 allocs/op
+BenchmarkDeterministicHash_1000-8            	 2181520	       557.1 ns/op	    1080 B/op	       3 allocs/op
+BenchmarkDeterministicHash_Salted_1000-8     	 1465852	       814.1 ns/op	    1576 B/op	       9 allocs/op
+BenchmarkDeterministicHash_SHA512_1000-8     	 1349864	       871.5 ns/op	    1112 B/op	       3 allocs/op
+BenchmarkDeterministicHash_SHA3_256_1000-8   	  832321	      1419 ns/op	    1088 B/op	       3 allocs/op
+BenchmarkReducePrecision_NumericShort-8      	32811463	        36.47 ns/op	      16 B/op	       1 allocs/op
+BenchmarkReducePrecision_NumericLong-8       	  346722	      3520 ns/op	    1024 B/op	       1 allocs/op
+BenchmarkReducePrecision_Fallback-8          	35827980	        33.48 ns/op	       8 B/op	       1 allocs/op
+PASS
+ok  	github.com/axonops/mask	27.607s

--- a/doc.go
+++ b/doc.go
@@ -71,6 +71,22 @@
 // [SetMaskChar] or per instance with [WithMaskChar]. Built-in rules read the
 // configured character at apply time so changes are picked up immediately.
 //
+// # Non-goals
+//
+// The API does not accept [context.Context]. Masking is pure compute with no
+// I/O, no goroutines, and no blocking operations; a context would never be
+// consulted and would mislead callers into expecting cancellation or deadline
+// semantics that cannot be honoured. This mirrors the stdlib strings,
+// strconv and encoding/* packages, which also do not accept context.
+//
+// If a future rule legitimately requires per-request metadata — for example
+// a policy-driven rule that varies by tenant — that metadata belongs on a
+// dedicated [Masker] instance constructed via [New], not smuggled through a
+// context value. If a future built-in rule cannot be implemented without
+// I/O (for example an HSM-backed tokeniser calling a remote KMS), the right
+// move is a separate subpackage with its own context-aware interface —
+// leaving the core [Apply] signature untouched.
+//
 // # Further reading
 //
 //   - The full rule catalogue lives in docs/v0.9.0-requirements.md.

--- a/docs/v0.9.0-requirements.md
+++ b/docs/v0.9.0-requirements.md
@@ -741,11 +741,30 @@ These are the composable building blocks. All domain rules above are thin wrappe
 - Example (n=4): `SensitiveData` → `Sens`
 
 #### `deterministic_hash`
-- Replace value with a truncated SHA-256 hex digest
-- Default: first 16 hex chars prefixed with `sha256:`
+- Replace value with a truncated cryptographic digest, prefixed with the algorithm name.
+- **Default:** SHA-256, no salt, first 16 hex chars prefixed with `sha256:`.
+- Built-in rule `deterministic_hash` applies the default.
 - Example: `alice@example.com` → `sha256:a1b2c3d4e5f6a7b8`
 - Note: This is pseudonymisation, NOT anonymisation. Same input always produces same output, enabling correlation without exposure.
-- Security: Must use `crypto/sha256`, never MD5 or SHA1
+- **Security:** MUST use an approved cryptographic hash. Supported algorithms (stdlib only): SHA-256 (default), SHA-512, SHA3-256, SHA3-512. MD5 and SHA-1 are forbidden.
+
+##### Configurable variants
+
+Two optional parameters are exposed via functional options on the direct-call parametric variant and the factory:
+
+1. **Algorithm selection** — `WithAlgorithm(HashAlgorithm)` where `HashAlgorithm` is an enum with values `SHA256` (default), `SHA512`, `SHA3_256`, `SHA3_512`. The output prefix changes with the algorithm: `sha256:`, `sha512:`, `sha3-256:`, `sha3-512:`.
+2. **Salt** — `WithSalt(string)`. When a salt is provided, the value is hashed as `HMAC(salt, value)` using the selected algorithm. When no salt is provided, the value is hashed directly with the selected algorithm. HMAC is chosen over concatenation because it is the standard primitive for keyed hashing and sidesteps length-extension concerns for SHA-2 family algorithms. The salt MUST remain constant for the lifetime of the process; rotating it breaks determinism and therefore correlation — which is usually the opposite of what consumers want from this primitive.
+
+The built-in registered rule `deterministic_hash` continues to use SHA-256 with no salt (equivalent to `DeterministicHashFunc()` with zero options). Consumers who want a salted or alternative-algorithm variant register a named rule via the factory, e.g.:
+
+```go
+m.Register("hashed_email", mask.DeterministicHashFunc(
+    mask.WithSalt(os.Getenv("MASK_SALT")),
+    mask.WithAlgorithm(mask.SHA512),
+))
+```
+
+`HashAlgorithm.String()` returns the prefix form (`"sha256"`, `"sha512"`, `"sha3-256"`, `"sha3-512"`) and is the authoritative source for the output prefix — the emitter and the stringer share one table.
 
 #### `nullify`
 - Replace value with empty string

--- a/hash.go
+++ b/hash.go
@@ -1,0 +1,272 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha3"
+	"crypto/sha512"
+	"encoding/hex"
+	"hash"
+)
+
+// HashAlgorithm selects the cryptographic hash used by the deterministic-hash
+// primitives. The zero value is [SHA256], the library default. MD5 and SHA-1
+// are not supported and will never be added — they are cryptographically
+// broken for collision resistance and have no place in a masking library.
+type HashAlgorithm int
+
+// SHA3_256 and SHA3_512 deliberately mirror the stdlib crypto.SHA3_256 /
+// crypto.SHA3_512 naming so callers switching between the two packages do
+// not have to remember which underscore rule applies. The revive var-naming
+// rule is suppressed on those two lines for that reason.
+const (
+	// SHA256 is the default. Output prefix "sha256".
+	SHA256 HashAlgorithm = iota
+	// SHA512 uses SHA-512. Output prefix "sha512".
+	SHA512
+	// SHA3_256 uses SHA3-256. Output prefix "sha3-256".
+	SHA3_256 //nolint:revive // matches stdlib crypto.SHA3_256
+	// SHA3_512 uses SHA3-512. Output prefix "sha3-512".
+	SHA3_512 //nolint:revive // matches stdlib crypto.SHA3_512
+
+	// maxHashAlgorithm is the exclusive upper bound used for range checks.
+	maxHashAlgorithm
+)
+
+// algoEntry pairs the on-the-wire prefix with the constructor used to build a
+// fresh [hash.Hash]. The algoTable is the single source of truth for both the
+// prefix reported by [HashAlgorithm.String] and the bytes emitted on the
+// wire — diverging the two is a bug.
+type algoEntry struct {
+	prefix string
+	ctor   func() hash.Hash
+}
+
+// sha3.New256/New512 return *sha3.SHA3, which satisfies hash.Hash but cannot
+// be assigned to a func() hash.Hash directly; wrap them in adapter closures.
+var algoTable = [maxHashAlgorithm]algoEntry{
+	SHA256:   {"sha256", sha256.New},
+	SHA512:   {"sha512", sha512.New},
+	SHA3_256: {"sha3-256", func() hash.Hash { return sha3.New256() }},
+	SHA3_512: {"sha3-512", func() hash.Hash { return sha3.New512() }},
+}
+
+// String returns the on-the-wire prefix for a.
+// Values outside the defined constants return the default "sha256".
+func (a HashAlgorithm) String() string {
+	if a < 0 || a >= maxHashAlgorithm {
+		return algoTable[SHA256].prefix
+	}
+	return algoTable[a].prefix
+}
+
+// hashConfig is the effective configuration produced by applying zero or more
+// [HashOption] values. The zero value corresponds to "unsalted SHA-256".
+type hashConfig struct {
+	algo HashAlgorithm
+	salt string // empty string means "no salt" — see WithSalt godoc
+}
+
+// HashOption configures the deterministic-hash primitives. Use with
+// [DeterministicHashWith] and [DeterministicHashFunc]. Options apply in
+// supplied order, last-wins for repeated options.
+type HashOption func(*hashConfig)
+
+// WithAlgorithm selects the hash algorithm. Values outside the four
+// supported constants silently clamp to [SHA256] so RuleFunc never panics on
+// a bad enum value — garbage in, safe default out.
+//
+// Supported algorithms and their output prefixes:
+//
+//   - SHA256   → "sha256"   (default)
+//   - SHA512   → "sha512"
+//   - SHA3_256 → "sha3-256"
+//   - SHA3_512 → "sha3-512"
+//
+// MD5 and SHA-1 are explicitly unsupported.
+func WithAlgorithm(a HashAlgorithm) HashOption {
+	if a < 0 || a >= maxHashAlgorithm {
+		a = SHA256
+	}
+	return func(c *hashConfig) {
+		c.algo = a
+	}
+}
+
+// WithSalt enables keyed hashing via HMAC. When a non-empty salt is supplied,
+// the primitive emits HMAC(salt, value) using the selected algorithm.
+//
+// An empty salt string is treated as "no salt" and the primitive emits
+// unsalted hash(value). This collapse is deliberate: HMAC with an empty key
+// is technically valid but provides no keying material and would be a
+// cryptographic footgun disguised as an intentional choice. If you truly
+// want empty-key HMAC, use the crypto/hmac package directly.
+//
+// The salt MUST remain constant for the lifetime of the process. Rotating it
+// breaks determinism, and therefore breaks the correlation properties that
+// are the reason this primitive exists. Salt values are never logged, echoed
+// in output, returned in error messages, or exposed via [Describe].
+//
+// Operational note: the salt is an in-memory Go string and may appear in
+// process core dumps or goroutine stacks. Protect the process, not the
+// library.
+func WithSalt(salt string) HashOption {
+	return func(c *hashConfig) {
+		c.salt = salt
+	}
+}
+
+// resolveAlgo returns a valid [HashAlgorithm] for the given config, clamping
+// out-of-range values to [SHA256]. This is a defence-in-depth guard — the
+// option constructor already clamps on apply, but a future change that sets
+// hashConfig.algo directly should not be able to panic the dispatch path.
+func resolveAlgo(a HashAlgorithm) HashAlgorithm {
+	if a < 0 || a >= maxHashAlgorithm {
+		return SHA256
+	}
+	return a
+}
+
+// hashSumUnsalted returns the raw digest of v using the selected algorithm.
+// The unsalted path uses the fixed-size Sum* functions, which do not allocate
+// a [hash.Hash] on the heap.
+func hashSumUnsalted(algo HashAlgorithm, v string) []byte {
+	switch algo {
+	case SHA256:
+		sum := sha256.Sum256([]byte(v))
+		return sum[:]
+	case SHA512:
+		sum := sha512.Sum512([]byte(v))
+		return sum[:]
+	case SHA3_256:
+		sum := sha3.Sum256([]byte(v))
+		return sum[:]
+	case SHA3_512:
+		sum := sha3.Sum512([]byte(v))
+		return sum[:]
+	default:
+		// Unreachable because callers pass resolveAlgo'd values. Fall back
+		// safely.
+		sum := sha256.Sum256([]byte(v))
+		return sum[:]
+	}
+}
+
+// hashSumSalted returns HMAC(salt, v) using the selected algorithm. The algo
+// value is clamped to a valid entry by [resolveAlgo] on the calling path,
+// but we clamp again here so any future direct caller can't panic on an
+// out-of-range index — this mirrors the defensive fallback in
+// [hashSumUnsalted].
+func hashSumSalted(algo HashAlgorithm, salt, v string) []byte {
+	algo = resolveAlgo(algo)
+	h := hmac.New(algoTable[algo].ctor, []byte(salt))
+	h.Write([]byte(v))
+	return h.Sum(nil)
+}
+
+// hashApply is the single dispatch point for all deterministic-hash callers.
+// It branches on whether a salt is present, runs the chosen primitive, and
+// emits "<prefix>:<first-16-hex>".
+func hashApply(cfg hashConfig, v string) string {
+	algo := resolveAlgo(cfg.algo)
+	var sum []byte
+	if cfg.salt == "" {
+		sum = hashSumUnsalted(algo, v)
+	} else {
+		sum = hashSumSalted(algo, cfg.salt, v)
+	}
+	// Defence against a future algorithm with a shorter digest. Every
+	// currently supported algorithm produces ≥ 32 bytes.
+	if len(sum) < 8 {
+		return algoTable[algo].prefix + ":"
+	}
+	prefix := algoTable[algo].prefix
+	dst := make([]byte, 0, len(prefix)+1+16)
+	dst = append(dst, prefix...)
+	dst = append(dst, ':')
+	dst = hex.AppendEncode(dst, sum[:8])
+	return string(dst)
+}
+
+// DeterministicHash replaces v with a truncated SHA-256 hex digest of the
+// input, prefixed with the algorithm name. The output is 23 bytes:
+// "sha256:" plus 16 hexadecimal characters encoding the first 8 bytes of the
+// digest.
+//
+// This primitive performs **pseudonymisation, not anonymisation**. The same
+// input always produces the same output, which is the point — it lets a
+// consumer correlate records without seeing the original value. The flip
+// side is that anyone with the original value can compute the same digest,
+// and the truncation to 64 bits means collisions are expected on corpora
+// above roughly 10^9 distinct values (birthday bound 2^32).
+//
+// The input is hashed as its raw UTF-8 byte sequence. No Unicode
+// normalisation is performed, so the NFC and NFD forms of the same string
+// produce different outputs. Callers handling multilingual data should
+// normalise before hashing.
+//
+// For a keyed variant or a different algorithm, use [DeterministicHashWith]
+// or build a [RuleFunc] via [DeterministicHashFunc].
+//
+// Example: DeterministicHash("alice@example.com") → "sha256:559aead08264d592".
+func DeterministicHash(v string) string {
+	return hashApply(hashConfig{algo: SHA256}, v)
+}
+
+// DeterministicHashWith is the parametric direct-call variant of
+// [DeterministicHash]. Options apply in supplied order, last-wins.
+//
+// This helper is for one-off ad-hoc use. Hot paths should construct a
+// [RuleFunc] once via [DeterministicHashFunc] and reuse it — a `...HashOption`
+// variadic is allocated on every call here.
+//
+// Example:
+//
+//	h := mask.DeterministicHashWith("alice", mask.WithAlgorithm(mask.SHA512))
+//	// h == "sha512:..."
+func DeterministicHashWith(v string, opts ...HashOption) string {
+	var cfg hashConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return hashApply(cfg, v)
+}
+
+// DeterministicHashFunc builds a [RuleFunc] that hashes its input according
+// to the supplied options. The returned function is safe for concurrent use
+// and captures a frozen [hashConfig] at construction time — later edits to
+// the supplied options slice do not affect it.
+//
+// Zero-option use is guaranteed to produce output byte-identical to
+// [DeterministicHash]; this equivalence is how the built-in `deterministic_hash`
+// rule is registered without duplicating the SHA-256 code path.
+//
+// Example:
+//
+//	_ = m.Register("hashed_email", mask.DeterministicHashFunc(
+//	    mask.WithSalt(os.Getenv("MASK_SALT")),
+//	    mask.WithAlgorithm(mask.SHA3_256),
+//	))
+func DeterministicHashFunc(opts ...HashOption) RuleFunc {
+	var cfg hashConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return func(v string) string {
+		return hashApply(cfg, v)
+	}
+}

--- a/mask.go
+++ b/mask.go
@@ -164,11 +164,18 @@ func (m *Masker) ensureInit() {
 }
 
 // setMaskChar is the internal mask-character setter used by [WithMaskChar] and
-// by the package-level [SetMaskChar]. The getter used by built-in rules lives
-// in the file that introduces them (Phase 3).
+// by the package-level [SetMaskChar].
 func (m *Masker) setMaskChar(c rune) {
 	m.ensureInit()
 	m.maskCharAtomic.Store(c)
+}
+
+// maskChar returns the mask rune currently configured on this Masker.
+// Built-in registrars close over the Masker and call maskChar inside the
+// produced RuleFunc so that a later WithMaskChar or SetMaskChar call takes
+// effect on every subsequent Apply without requiring re-registration.
+func (m *Masker) maskChar() rune {
+	return m.maskCharAtomic.Load()
 }
 
 // Apply masks value using the named rule.

--- a/primitives.go
+++ b/primitives.go
@@ -1,0 +1,506 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// safeRuneLen returns the UTF-8 byte width of c. For any invalid rune
+// (negative value, lone surrogate, value above unicode.MaxRune) it returns
+// the maximum valid rune width so downstream Builder.Grow calls never
+// receive a negative argument. This keeps the library's "no panic on any
+// input" contract intact even when a caller passes an obviously bad mask
+// rune via WithMaskChar or SetMaskChar.
+//
+// The helper exists only to keep capacity calculations non-negative — it
+// does not attempt to emit a valid rune. The subsequent Builder.WriteRune
+// call uses strings.Builder's own fallback (utf8.RuneError) for invalid
+// runes, so the output stays well-formed UTF-8.
+func safeRuneLen(c rune) int {
+	n := utf8.RuneLen(c)
+	if n < 0 {
+		return utf8.UTFMax
+	}
+	return n
+}
+
+// FullRedact replaces the value with the constant [FullRedactMarker], losing
+// both length and contents. Use when the existence of a value is itself the
+// only information that should survive.
+//
+// Example: FullRedact("anything") → "[REDACTED]".
+func FullRedact(_ string) string {
+	return FullRedactMarker
+}
+
+// Nullify replaces any value with the empty string. Prefer [FullRedact] when a
+// downstream consumer must distinguish "field was present and redacted" from
+// "field was absent".
+//
+// Example: Nullify("anything") → "".
+func Nullify(_ string) string {
+	return ""
+}
+
+// FixedReplacementFunc builds a [RuleFunc] that always returns replacement
+// regardless of input. The replacement is captured at construction, so
+// changes to the global or per-instance mask character do NOT affect it.
+//
+// Example:
+//
+//	r := mask.FixedReplacementFunc("N/A")
+//	r("secret") // "N/A"
+//	r("")      // "N/A"
+func FixedReplacementFunc(replacement string) RuleFunc {
+	return func(_ string) string {
+		return replacement
+	}
+}
+
+// SameLengthMask replaces every rune of v with the mask rune c while
+// preserving the rune count of the input. Unicode aware — input `"Hello"`
+// with c='*' yields `"*****"` regardless of the byte width of the mask rune.
+//
+// Example: SameLengthMask("Hello", '*') → "*****".
+func SameLengthMask(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	runeCount := utf8.RuneCountInString(v)
+	var b strings.Builder
+	b.Grow(runeCount * safeRuneLen(c))
+	for i := 0; i < runeCount; i++ {
+		b.WriteRune(c)
+	}
+	return b.String()
+}
+
+// KeepFirstN preserves the first n runes of v and replaces the remainder with
+// the mask rune c. Negative n is treated as 0. n greater than or equal to the
+// rune count of v returns v unchanged.
+//
+// Example: KeepFirstN("Sensitive", 4, '*') → "Sens*****".
+func KeepFirstN(v string, n int, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if n < 0 {
+		n = 0
+	}
+	runeCount := utf8.RuneCountInString(v)
+	if n >= runeCount {
+		return v
+	}
+	cutByte := byteOffsetAtRune(v, n)
+	tailRunes := runeCount - n
+	var b strings.Builder
+	b.Grow(cutByte + tailRunes*safeRuneLen(c))
+	b.WriteString(v[:cutByte])
+	for i := 0; i < tailRunes; i++ {
+		b.WriteRune(c)
+	}
+	return b.String()
+}
+
+// KeepLastN preserves the last n runes of v and replaces the preceding runes
+// with the mask rune c. Negative n is treated as 0. n greater than or equal to
+// the rune count of v returns v unchanged.
+//
+// Example: KeepLastN("Sensitive", 4, '*') → "*****tive".
+func KeepLastN(v string, n int, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if n < 0 {
+		n = 0
+	}
+	runeCount := utf8.RuneCountInString(v)
+	if n >= runeCount {
+		return v
+	}
+	tailByte := byteOffsetAtRune(v, runeCount-n)
+	headRunes := runeCount - n
+	var b strings.Builder
+	b.Grow(headRunes*safeRuneLen(c) + (len(v) - tailByte))
+	for i := 0; i < headRunes; i++ {
+		b.WriteRune(c)
+	}
+	b.WriteString(v[tailByte:])
+	return b.String()
+}
+
+// KeepFirstLast preserves the first and last runes of v and masks the middle
+// with c. Negative values are clamped to 0. If first+last is greater than or
+// equal to the rune count of v, v is returned unchanged — this is the safe
+// degradation required by the spec and avoids ever producing output longer
+// than the input.
+//
+// Example: KeepFirstLast("SensitiveData", 4, 4, '*') → "Sens*****Data".
+func KeepFirstLast(v string, first, last int, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if first < 0 {
+		first = 0
+	}
+	if last < 0 {
+		last = 0
+	}
+	runeCount := utf8.RuneCountInString(v)
+	if first+last >= runeCount {
+		return v
+	}
+	headByte := byteOffsetAtRune(v, first)
+	tailByte := byteOffsetAtRune(v, runeCount-last)
+	middleRunes := runeCount - first - last
+	var b strings.Builder
+	b.Grow(headByte + middleRunes*safeRuneLen(c) + (len(v) - tailByte))
+	b.WriteString(v[:headByte])
+	for i := 0; i < middleRunes; i++ {
+		b.WriteRune(c)
+	}
+	b.WriteString(v[tailByte:])
+	return b.String()
+}
+
+// TruncateVisible returns the first n runes of v with no mask characters
+// appended. Values of n ≤ 0 produce the empty string; n ≥ the rune count of
+// v returns v unchanged. Unicode aware.
+//
+// Example: TruncateVisible("Sensitive", 4) → "Sens".
+//
+// WARNING: TruncateVisible is a formatting helper, not a masking primitive.
+// It does NOT fail closed — when n ≥ the rune count of v it returns v
+// verbatim. Use it only in composition with an actual masking primitive
+// (for example chained after [KeepFirstN] to clip a too-long visible
+// prefix). Registering TruncateVisible directly as a masking rule will
+// produce data leaks on short inputs.
+func TruncateVisible(v string, n int) string {
+	if n <= 0 || v == "" {
+		return ""
+	}
+	seen := 0
+	for i := range v {
+		if seen == n {
+			return v[:i]
+		}
+		seen++
+	}
+	return v
+}
+
+// PreserveDelimiters replaces every rune of v with c, except runes listed in
+// delim, which are kept verbatim. Useful when a format's separators carry
+// structural meaning (for example, the dashes in a payment card number).
+//
+// Example: PreserveDelimiters("ab-cd", "-", '*') → "**-**".
+//
+// The direct-call helper rebuilds the delimiter set on every invocation. For
+// hot paths construct a factory once with [PreserveDelimitersFunc].
+func PreserveDelimiters(v, delim string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	return preserveDelimitersWithScan(v, delim, c)
+}
+
+// preserveDelimitersWithScan is the shared core. It uses a linear scan over
+// the delimiter runes — optimal for the common 1–5 delimiter case.
+func preserveDelimitersWithScan(v, delim string, c rune) string {
+	delimRunes := []rune(delim)
+	var b strings.Builder
+	b.Grow(len(v))
+	for _, r := range v {
+		if containsRune(delimRunes, r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+func containsRune(rs []rune, needle rune) bool {
+	for _, r := range rs {
+		if r == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ReplaceRegex applies the regex pattern to v and replaces every match with
+// replacement. Returns the original pattern compilation error if pattern is
+// malformed; the value argument is never included in the error message.
+//
+// This function compiles pattern on every call. For hot-path use, call
+// [ReplaceRegexFunc] once and reuse the returned [RuleFunc].
+//
+// Example: ReplaceRegex("id-42", `\d+`, "N") → ("id-N", nil).
+func ReplaceRegex(v, pattern, replacement string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("mask: invalid regex pattern: %w", err)
+	}
+	return re.ReplaceAllString(v, replacement), nil
+}
+
+// ReplaceRegexFunc compiles pattern once and returns a [RuleFunc] that
+// applies it on every call. An invalid pattern returns a wrapped error and a
+// nil [RuleFunc] — never panics.
+func ReplaceRegexFunc(pattern, replacement string) (RuleFunc, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("mask: invalid regex pattern: %w", err)
+	}
+	return func(v string) string {
+		return re.ReplaceAllString(v, replacement)
+	}, nil
+}
+
+// TruncateVisibleFunc builds a [RuleFunc] that truncates its input to the
+// first n runes. See [TruncateVisible] for boundary behaviour.
+func TruncateVisibleFunc(n int) RuleFunc {
+	return func(v string) string {
+		return TruncateVisible(v, n)
+	}
+}
+
+// ReducePrecision reduces the decimal-place precision of a numeric string by
+// preserving all characters up to and including decimals digits after the
+// decimal point, and replacing every subsequent digit with c. Non-numeric
+// input, scientific notation, multiple decimal points, NaN, and ±Infinity
+// all fall back to [SameLengthMask] so the primitive never returns the
+// original value.
+//
+// The primitive works on the original string byte by byte — it does not
+// round-trip the value through a float, so leading zeros, trailing zeros,
+// and signs are preserved exactly.
+//
+// Examples:
+//
+//	ReducePrecision("37.7749295", 2, '*') // "37.77*****"
+//	ReducePrecision("-37.7749",   2, '*') // "-37.77**"
+//	ReducePrecision("42",         2, '*') // "42" (no fractional part)
+//	ReducePrecision("1.2e5",      2, '*') // "*****" (scientific not accepted)
+func ReducePrecision(v string, decimals int, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if decimals < 0 {
+		decimals = 0
+	}
+	if !isPlainDecimal(v) {
+		return SameLengthMask(v, c)
+	}
+	// A plain decimal has at most one '.'. Find it.
+	dot := strings.IndexByte(v, '.')
+	if dot < 0 {
+		// No fractional part — nothing to mask.
+		return v
+	}
+	// Position of the first digit to mask, measured in bytes from start of v.
+	// decimals == 0 means "mask everything after the dot".
+	// decimals == n means "preserve n digits after the dot".
+	cut := dot + 1 + decimals
+	if cut >= len(v) {
+		return v
+	}
+	// Mask every digit after the cut. All trailing chars are guaranteed ASCII
+	// digits by isPlainDecimal.
+	tail := len(v) - cut
+	var b strings.Builder
+	b.Grow(cut + tail*safeRuneLen(c))
+	b.WriteString(v[:cut])
+	for i := 0; i < tail; i++ {
+		b.WriteRune(c)
+	}
+	return b.String()
+}
+
+// ReducePrecisionFunc builds a [RuleFunc] that reduces decimal precision.
+// See [ReducePrecision] for semantics.
+func ReducePrecisionFunc(decimals int) RuleFunc {
+	return func(v string) string {
+		return ReducePrecision(v, decimals, DefaultMaskChar)
+	}
+}
+
+// KeepFirstNFunc returns a [RuleFunc] that keeps the first n runes, masking
+// the rest with [DefaultMaskChar]. See [KeepFirstN].
+//
+// Mask-character note: factories capture [DefaultMaskChar] at construction
+// and ignore later per-Masker overrides configured via [WithMaskChar] or
+// [SetMaskChar]. A caller who needs the instance mask character should use
+// the direct-call helper inside a closure: for example
+//
+//	r := func(v string) string { return mask.KeepFirstN(v, 4, m.MaskChar()) }
+//
+// (where `m.MaskChar()` reads whatever state the caller tracks). The
+// factory's stability is deliberate: registered parametric rules should not
+// change output when a global knob is turned.
+func KeepFirstNFunc(n int) RuleFunc {
+	return func(v string) string {
+		return KeepFirstN(v, n, DefaultMaskChar)
+	}
+}
+
+// KeepLastNFunc returns a [RuleFunc] that keeps the last n runes, masking
+// the rest with [DefaultMaskChar]. See [KeepLastN]. The same mask-character
+// capture semantics as [KeepFirstNFunc] apply.
+func KeepLastNFunc(n int) RuleFunc {
+	return func(v string) string {
+		return KeepLastN(v, n, DefaultMaskChar)
+	}
+}
+
+// KeepFirstLastFunc returns a [RuleFunc] that keeps the first and last runes
+// and masks the middle. See [KeepFirstLast]. The same mask-character capture
+// semantics as [KeepFirstNFunc] apply.
+func KeepFirstLastFunc(first, last int) RuleFunc {
+	return func(v string) string {
+		return KeepFirstLast(v, first, last, DefaultMaskChar)
+	}
+}
+
+// PreserveDelimitersFunc returns a [RuleFunc] that masks v with
+// [DefaultMaskChar] while preserving runes listed in delim. The delimiter
+// set is captured once at construction and reused on every call. The same
+// mask-character capture semantics as [KeepFirstNFunc] apply.
+func PreserveDelimitersFunc(delim string) RuleFunc {
+	delimSet := make(map[rune]struct{}, len(delim))
+	for _, r := range delim {
+		delimSet[r] = struct{}{}
+	}
+	return func(v string) string {
+		if v == "" {
+			return ""
+		}
+		var b strings.Builder
+		b.Grow(len(v))
+		for _, r := range v {
+			if _, ok := delimSet[r]; ok {
+				b.WriteRune(r)
+			} else {
+				b.WriteRune(DefaultMaskChar)
+			}
+		}
+		return b.String()
+	}
+}
+
+// byteOffsetAtRune returns the byte index in s where the rune at position idx
+// begins. idx must be in the range [0, RuneCount(s)] — an idx equal to the
+// rune count returns len(s). The caller is responsible for clamping.
+func byteOffsetAtRune(s string, idx int) int {
+	if idx <= 0 {
+		return 0
+	}
+	seen := 0
+	for i := range s {
+		if seen == idx {
+			return i
+		}
+		seen++
+	}
+	return len(s)
+}
+
+// isPlainDecimal reports whether s is a sign (optional) followed by ASCII
+// digits, with at most one '.' and at least one digit. Scientific notation,
+// NaN, Inf, commas, whitespace, and multiple dots all return false. Used by
+// [ReducePrecision] to decide when to fall back to [SameLengthMask].
+func isPlainDecimal(s string) bool {
+	if s == "" {
+		return false
+	}
+	i := 0
+	if s[0] == '+' || s[0] == '-' {
+		i++
+		if i == len(s) {
+			return false
+		}
+	}
+	sawDigit := false
+	sawDot := false
+	for ; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+			sawDigit = true
+		case ch == '.':
+			if sawDot {
+				return false
+			}
+			sawDot = true
+		default:
+			return false
+		}
+	}
+	return sawDigit
+}
+
+// registerPrimitives is appended to builtinRegistrars from init. It populates
+// every Masker — zero-value, package-level default, and per-instance — with
+// the primitives that have fixed semantics (no parameters from the caller).
+//
+// Parametric primitives (KeepFirstN, ReplaceRegex, etc.) are NOT registered
+// as named rules here; consumers construct them via the `...Func` factories
+// and call [Masker.Register] with a name of their choosing.
+func registerPrimitives(m *Masker) {
+	m.mustRegisterBuiltin("full_redact",
+		func(_ string) string { return FullRedactMarker },
+		RuleInfo{
+			Name:         "full_redact",
+			Category:     "utility",
+			Jurisdiction: "global",
+			Description:  "replaces any value with the constant [REDACTED]",
+		})
+
+	m.mustRegisterBuiltin("same_length_mask",
+		func(v string) string { return SameLengthMask(v, m.maskChar()) },
+		RuleInfo{
+			Name:         "same_length_mask",
+			Category:     "utility",
+			Jurisdiction: "global",
+			Description:  "replaces every rune of the input with the configured mask character, preserving length",
+		})
+
+	m.mustRegisterBuiltin("nullify",
+		func(_ string) string { return "" },
+		RuleInfo{
+			Name:         "nullify",
+			Category:     "utility",
+			Jurisdiction: "global",
+			Description:  "replaces any value with the empty string",
+		})
+
+	m.mustRegisterBuiltin("deterministic_hash",
+		DeterministicHashFunc(),
+		RuleInfo{
+			Name:         "deterministic_hash",
+			Category:     "utility",
+			Jurisdiction: "global",
+			Description:  "replaces the value with a truncated SHA-256 digest (sha256:<first-16-hex>); pseudonymisation only",
+		})
+}
+
+func init() {
+	builtinRegistrars = append(builtinRegistrars, registerPrimitives)
+}

--- a/primitives_bench_test.go
+++ b/primitives_bench_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/axonops/mask"
+)
+
+var (
+	sink     string
+	short16  = "SensitiveData123"
+	long1000 = strings.Repeat("s", 1000)
+)
+
+func BenchmarkFullRedact(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.FullRedact(short16)
+	}
+	sink = s
+}
+
+func BenchmarkSameLengthMask_1000(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.SameLengthMask(long1000, '*')
+	}
+	sink = s
+}
+
+func BenchmarkKeepFirstN_16(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.KeepFirstN(short16, 4, '*')
+	}
+	sink = s
+}
+
+func BenchmarkKeepFirstN_1000(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.KeepFirstN(long1000, 4, '*')
+	}
+	sink = s
+}
+
+func BenchmarkKeepLastN_16(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.KeepLastN(short16, 4, '*')
+	}
+	sink = s
+}
+
+func BenchmarkKeepLastN_1000(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.KeepLastN(long1000, 4, '*')
+	}
+	sink = s
+}
+
+func BenchmarkKeepFirstLast_16(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.KeepFirstLast(short16, 4, 4, '*')
+	}
+	sink = s
+}
+
+func BenchmarkKeepFirstLast_1000(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.KeepFirstLast(long1000, 4, 4, '*')
+	}
+	sink = s
+}
+
+func BenchmarkTruncateVisible_16(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.TruncateVisible(short16, 4)
+	}
+	sink = s
+}
+
+func BenchmarkTruncateVisible_1000(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.TruncateVisible(long1000, 4)
+	}
+	sink = s
+}
+
+func BenchmarkPreserveDelimiters_Email(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.PreserveDelimiters("alice@example.com", "@.", '*')
+	}
+	sink = s
+}
+
+func BenchmarkPreserveDelimitersFunc_Email(b *testing.B) {
+	r := mask.PreserveDelimitersFunc("@.")
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = r("alice@example.com")
+	}
+	sink = s
+}
+
+func BenchmarkReplaceRegexFunc_1000(b *testing.B) {
+	r, err := mask.ReplaceRegexFunc(`\d+`, "N")
+	if err != nil {
+		b.Fatal(err)
+	}
+	input := strings.Repeat("abc-42 ", 200)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = r(input)
+	}
+	sink = s
+}
+
+func BenchmarkDeterministicHash_1000(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.DeterministicHash(long1000)
+	}
+	sink = s
+}
+
+func BenchmarkDeterministicHash_Salted_1000(b *testing.B) {
+	r := mask.DeterministicHashFunc(mask.WithSalt("secretkey"))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = r(long1000)
+	}
+	sink = s
+}
+
+func BenchmarkDeterministicHash_SHA512_1000(b *testing.B) {
+	r := mask.DeterministicHashFunc(mask.WithAlgorithm(mask.SHA512))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = r(long1000)
+	}
+	sink = s
+}
+
+func BenchmarkDeterministicHash_SHA3_256_1000(b *testing.B) {
+	r := mask.DeterministicHashFunc(mask.WithAlgorithm(mask.SHA3_256))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = r(long1000)
+	}
+	sink = s
+}
+
+func BenchmarkReducePrecision_NumericShort(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.ReducePrecision("37.7749295", 2, '*')
+	}
+	sink = s
+}
+
+func BenchmarkReducePrecision_NumericLong(b *testing.B) {
+	long := "37." + strings.Repeat("7", 998)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.ReducePrecision(long, 2, '*')
+	}
+	sink = s
+}
+
+// BenchmarkReducePrecision_Fallback exercises the non-numeric fallback path
+// (same_length_mask). Regression here indicates the fallback changed shape.
+func BenchmarkReducePrecision_Fallback(b *testing.B) {
+	b.ReportAllocs()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = mask.ReducePrecision("1.2e5", 2, '*')
+	}
+	sink = s
+}

--- a/primitives_internal_test.go
+++ b/primitives_internal_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeterministicHash_NoMD5orSHA1Imports asserts that no .go file in this
+// package imports crypto/md5 or crypto/sha1. This is defence in depth: a
+// future change that downgrades the hash algorithm — accidentally or
+// otherwise — fails at CI rather than silently shipping a weak pseudonym.
+//
+// A substring grep is deliberately rejected: "sha3-256" contains the
+// substring "sha1" via unfortunate coincidence only when you misread, but
+// other false positives ("sha1something") are the real risk. Parsing the
+// AST and inspecting the import path strings is unambiguous.
+func TestDeterministicHash_NoMD5orSHA1Imports(t *testing.T) {
+	t.Parallel()
+
+	// Walk the current package directory only. The Go test binary's working
+	// directory is the package directory.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	forbidden := map[string]struct{}{
+		`"crypto/md5"`:  {},
+		`"crypto/sha1"`: {},
+	}
+
+	var offenders []string
+	err = filepath.WalkDir(wd, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			// Skip sub-test suites so we only scan package-level files.
+			if path != wd && filepath.Base(path) == "tests" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			// The rule applies to production sources; tests may legitimately
+			// need to reference forbidden names in string literals (this
+			// file does, to declare the forbidden set).
+			return nil
+		}
+		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, imp := range f.Imports {
+			if _, bad := forbidden[imp.Path.Value]; bad {
+				offenders = append(offenders, path+" imports "+imp.Path.Value)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, offenders, "forbidden cryptographic imports found: %v", offenders)
+}

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -1,0 +1,787 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha3"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"hash"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/mask"
+)
+
+// ---------- FullRedact ----------
+
+func TestFullRedact_AlwaysReturnsRedactedConstant(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "a", "secret", "佐藤太郎", strings.Repeat("x", 1000), "\xff\xfe"}
+	for _, v := range cases {
+		t.Run(short(v), func(t *testing.T) {
+			assert.Equal(t, mask.FullRedactMarker, mask.FullRedact(v))
+		})
+	}
+}
+
+// ---------- Nullify ----------
+
+func TestNullify_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	for _, v := range []string{"", "a", "secret", "佐藤太郎"} {
+		assert.Equal(t, "", mask.Nullify(v))
+	}
+}
+
+// ---------- FixedReplacement ----------
+
+func TestFixedReplacementFunc_IgnoresInput(t *testing.T) {
+	t.Parallel()
+	r := mask.FixedReplacementFunc("N/A")
+	for _, v := range []string{"", "anything", "佐藤", strings.Repeat("z", 200)} {
+		assert.Equal(t, "N/A", r(v))
+	}
+}
+
+func TestFixedReplacementFunc_EmptyEqualsNullify(t *testing.T) {
+	t.Parallel()
+	empty := mask.FixedReplacementFunc("")
+	for _, v := range []string{"", "abc", "佐藤"} {
+		assert.Equal(t, mask.Nullify(v), empty(v))
+	}
+}
+
+func TestFixedReplacementFunc_UnaffectedByMaskCharChange(t *testing.T) {
+	// Intentionally NOT t.Parallel — mutates global mask char.
+	t.Cleanup(func() { mask.SetMaskChar(mask.DefaultMaskChar) })
+
+	r := mask.FixedReplacementFunc("[[CAPTURED]]")
+	mask.SetMaskChar('X')
+	assert.Equal(t, "[[CAPTURED]]", r("secret"))
+}
+
+// ---------- SameLengthMask ----------
+
+func TestSameLengthMask_PreservesLength_Unicode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		char  rune
+		want  string
+	}{
+		{"empty", "", '*', ""},
+		{"ascii", "Hello", '*', "*****"},
+		{"cjk", "佐藤太郎", '*', "****"},
+		{"combining", "e\u0301", '*', "**"}, // "é" decomposed → 2 runes
+		{"emoji zwj", "\U0001F468\u200D\U0001F469\u200D\U0001F467", '*', "*****"},
+		{"multibyte mask", "Hello", '※', "※※※※※"},
+		{"already masked", "****", '*', "****"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.SameLengthMask(tc.input, tc.char))
+		})
+	}
+}
+
+// ---------- KeepFirstN ----------
+
+func TestKeepFirstN_Boundaries(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		n     int
+		char  rune
+		want  string
+	}{
+		{"n zero", "abcdef", 0, '*', "******"},
+		{"n one", "abcdef", 1, '*', "a*****"},
+		{"n equals len", "abcdef", 6, '*', "abcdef"},
+		{"n greater than len", "abcdef", 99, '*', "abcdef"},
+		{"n negative", "abcdef", -1, '*', "******"},
+		{"empty input", "", 3, '*', ""},
+		{"unicode muller", "Müller", 3, '*', "Mül***"},
+		{"cjk", "佐藤太郎", 2, '*', "佐藤**"},
+		{"combining sequence", "e\u0301fg", 1, '*', "e***"}, // rune-level, documents split
+		{"emoji zwj break", "\U0001F468\u200D\U0001F469abc", 1, '*', "\U0001F468*****"},
+		{"already masked", "****", 2, '*', "****"},
+		{"non default char", "abc", 0, '#', "###"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.KeepFirstN(tc.input, tc.n, tc.char))
+		})
+	}
+}
+
+// ---------- KeepLastN ----------
+
+func TestKeepLastN_Boundaries(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		n     int
+		char  rune
+		want  string
+	}{
+		{"n zero", "abcdef", 0, '*', "******"},
+		{"n one", "abcdef", 1, '*', "*****f"},
+		{"n equals len", "abcdef", 6, '*', "abcdef"},
+		{"n greater than len", "abcdef", 99, '*', "abcdef"},
+		{"n negative", "abcdef", -1, '*', "******"},
+		{"empty input", "", 3, '*', ""},
+		{"unicode muller", "Müller", 3, '*', "***ler"},
+		{"cjk", "佐藤太郎", 2, '*', "**太郎"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.KeepLastN(tc.input, tc.n, tc.char))
+		})
+	}
+}
+
+// ---------- KeepFirstLast ----------
+
+func TestKeepFirstLast_OverlappingRanges(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		input       string
+		first, last int
+		char        rune
+		want        string
+	}{
+		{"first plus last equals len", "ABCD", 2, 2, '*', "ABCD"},
+		{"first plus last exceeds len", "ABCD", 3, 2, '*', "ABCD"},
+		{"first plus last is len minus one", "ABCDE", 2, 2, '*', "AB*DE"},
+		{"both negative", "abcd", -1, -1, '*', "****"},
+		{"both zero", "abcdef", 0, 0, '*', "******"},
+		{"single rune", "A", 1, 1, '*', "A"},
+		{"empty input", "", 2, 2, '*', ""},
+		{"canonical", "SensitiveData", 4, 4, '*', "Sens*****Data"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.KeepFirstLast(tc.input, tc.first, tc.last, tc.char))
+		})
+	}
+}
+
+func TestKeepFirstLast_Unicode(t *testing.T) {
+	t.Parallel()
+	// "María" is 5 runes: M, a, r, í, a.
+	// first=2, last=1 → 2 middle runes masked.
+	assert.Equal(t, "Ma**a", mask.KeepFirstLast("María", 2, 1, '*'))
+
+	// "e\u0301fg" is 4 runes: e, combining acute, f, g.
+	// first=2, last=1 → 1 middle rune masked.
+	assert.Equal(t, "e\u0301*g", mask.KeepFirstLast("e\u0301fg", 2, 1, '*'))
+
+	// "佐藤太郎" is 4 runes. first=1, last=1 → 2 middle runes masked.
+	assert.Equal(t, "佐**郎", mask.KeepFirstLast("佐藤太郎", 1, 1, '*'))
+}
+
+// ---------- TruncateVisible ----------
+
+// TestTruncateVisible_FailOpenBehaviourOnShortInput pins the documented
+// WARNING: TruncateVisible is a formatting helper, not fail-closed. For
+// n >= rune count the original value is returned. The warning in godoc is
+// prose; this test makes it a contract.
+func TestTruncateVisible_FailOpenBehaviourOnShortInput(t *testing.T) {
+	t.Parallel()
+	// n >= len: original returned verbatim (the fail-open property we document).
+	assert.Equal(t, "abc", mask.TruncateVisible("abc", 99))
+	assert.Equal(t, "abc", mask.TruncateVisible("abc", 3))
+	// Invalid UTF-8 passes through without panic and remains non-empty.
+	got := mask.TruncateVisible("\xff\xfe\xfd", 2)
+	assert.NotEmpty(t, got)
+	assert.NotEqual(t, "\xff\xfe\xfd", got)
+}
+
+func TestTruncateVisible_BasicAndUnicode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		n     int
+		want  string
+	}{
+		{"n zero", "abcdef", 0, ""},
+		{"n negative", "abcdef", -1, ""},
+		{"n equals len", "abcdef", 6, "abcdef"},
+		{"n greater than len", "abcdef", 99, "abcdef"},
+		{"n less than len", "abcdef", 3, "abc"},
+		{"unicode muller", "Müller", 3, "Mül"},
+		{"cjk", "佐藤太郎", 2, "佐藤"},
+		{"empty input", "", 3, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.TruncateVisible(tc.input, tc.n))
+		})
+	}
+}
+
+// ---------- PreserveDelimiters ----------
+
+func TestPreserveDelimiters_Email(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "*****@*******.***",
+		mask.PreserveDelimiters("alice@example.com", "@.", '*'))
+}
+
+func TestPreserveDelimiters_EdgeCases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		delim string
+		char  rune
+		want  string
+	}{
+		{"empty input", "", "@.", '*', ""},
+		{"empty delim equals same length mask", "abc", "", '*', "***"},
+		{"delim contains mask char", "a*b", "*", '*', "***"},
+		{"cjk delim", "佐藤・太郎。", "・。", '*', "**・**。"},
+		{"delim superset of input", "abc", "abcdef", '*', "abc"},
+		{"duplicate delim runes", "a@b@c", "@@", '*', "*@*@*"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.PreserveDelimiters(tc.input, tc.delim, tc.char))
+		})
+	}
+}
+
+func TestPreserveDelimitersFunc_CapturesDelimOnce(t *testing.T) {
+	t.Parallel()
+	r := mask.PreserveDelimitersFunc("-_")
+	assert.Equal(t, "***-***_***", r("abc-def_ghi"))
+}
+
+// TestFactory_CapturesDefaultMaskChar pins the documented behaviour that
+// every `...Func` factory captures [DefaultMaskChar] at construction and is
+// NOT affected by a later SetMaskChar call. A consumer who needs the
+// instance mask character must close over the direct-call helper.
+func TestFactory_CapturesDefaultMaskChar(t *testing.T) {
+	// Intentionally NOT t.Parallel — mutates global mask char.
+	t.Cleanup(func() { mask.SetMaskChar(mask.DefaultMaskChar) })
+
+	keep := mask.KeepFirstNFunc(2)
+	keepLast := mask.KeepLastNFunc(2)
+	keepBoth := mask.KeepFirstLastFunc(1, 1)
+	trunc := mask.TruncateVisibleFunc(2)
+	pres := mask.PreserveDelimitersFunc("-")
+	redprec := mask.ReducePrecisionFunc(1)
+
+	mask.SetMaskChar('X')
+
+	// All factories above were constructed BEFORE SetMaskChar. The mask
+	// rune they emit must remain '*'. TruncateVisible emits no mask rune.
+	assert.Equal(t, "se****", keep("secret"))
+	assert.Equal(t, "****et", keepLast("secret"))
+	assert.Equal(t, "s****t", keepBoth("secret"))
+	assert.Equal(t, "se", trunc("secret"))
+	assert.Equal(t, "*-*", pres("a-b"))
+	assert.Equal(t, "37.7*", redprec("37.77"))
+
+	// The direct-call helper sees the instance-level mask char when the
+	// caller passes it explicitly — proves the escape hatch works.
+	assert.Equal(t, "seXXXX", mask.KeepFirstN("secret", 2, 'X'))
+}
+
+// ---------- ReplaceRegex ----------
+
+func TestReplaceRegex_InvalidPattern_ReturnsError(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{"[a-", "(?P<name", "*"} {
+		t.Run(p, func(t *testing.T) {
+			_, err := mask.ReplaceRegex("irrelevant", p, "X")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "mask: invalid regex pattern")
+			// Value must not be in the error.
+			assert.NotContains(t, err.Error(), "irrelevant")
+		})
+	}
+}
+
+func TestReplaceRegex_HappyPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name                                  string
+		input, pattern, replacement, expected string
+	}{
+		{"no match", "abc", "z+", "X", "abc"},
+		{"backreference", "abc", "(a)(b)", "$2$1", "bac"},
+		{"digits to X", "id-42", `\d+`, "N", "id-N"},
+		{"literal 1 stays literal", "abc", "(a)", `\1`, `\1bc`},
+		{"empty replacement strips", "abc", "b", "", "ac"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mask.ReplaceRegex(tc.input, tc.pattern, tc.replacement)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestReplaceRegexFunc_CompiledOnce(t *testing.T) {
+	t.Parallel()
+	r, err := mask.ReplaceRegexFunc(`\d+`, "N")
+	require.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, "id-N", r("id-42"))
+	}
+}
+
+func TestReplaceRegexFunc_InvalidPatternReturnsError(t *testing.T) {
+	t.Parallel()
+	r, err := mask.ReplaceRegexFunc("[a-", "X")
+	require.Error(t, err)
+	assert.Nil(t, r)
+}
+
+// ---------- ReducePrecision ----------
+
+func TestReducePrecision_NumericAndNonNumeric(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		input    string
+		decimals int
+		char     rune
+		want     string
+	}{
+		{"canonical", "37.7749295", 2, '*', "37.77*****"},
+		{"negative sign preserved", "-37.7749", 2, '*', "-37.77**"},
+		{"positive sign preserved", "+37.77", 2, '*', "+37.77"},
+		{"leading zeros preserved", "037.70", 1, '*', "037.7*"},
+		{"integer no dot", "42", 2, '*', "42"},
+		{"decimals greater than fraction", "37.7", 5, '*', "37.7"},
+		{"scientific fallback", "1.2e5", 2, '*', "*****"},
+		{"nan fallback", "NaN", 2, '*', "***"},
+		{"inf fallback", "Inf", 2, '*', "***"},
+		{"multiple dots fallback", "1.2.3", 2, '*', "*****"},
+		{"comma fallback", "37,77", 2, '*', "*****"},
+		{"trailing whitespace fallback", "37.77 ", 2, '*', "******"},
+		{"empty", "", 2, '*', ""},
+		{"decimals negative clamps to zero", "37.7749", -1, '*', "37.****"},
+		{"dot only", ".", 2, '*', "*"},
+		{"leading dot", ".5", 1, '*', ".5"},
+		{"trailing dot", "5.", 1, '*', "5."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mask.ReducePrecision(tc.input, tc.decimals, tc.char))
+		})
+	}
+}
+
+func TestReducePrecisionFunc_UsesDefaultMaskChar(t *testing.T) {
+	t.Parallel()
+	r := mask.ReducePrecisionFunc(2)
+	assert.Equal(t, "37.77*****", r("37.7749295"))
+}
+
+// ---------- Remaining parametric factories ----------
+
+func TestKeepFirstNFunc_UsesDefaultMaskChar(t *testing.T) {
+	t.Parallel()
+	r := mask.KeepFirstNFunc(3)
+	assert.Equal(t, "abc***", r("abcdef"))
+}
+
+func TestKeepLastNFunc_UsesDefaultMaskChar(t *testing.T) {
+	t.Parallel()
+	r := mask.KeepLastNFunc(3)
+	assert.Equal(t, "***def", r("abcdef"))
+}
+
+func TestKeepFirstLastFunc_UsesDefaultMaskChar(t *testing.T) {
+	t.Parallel()
+	r := mask.KeepFirstLastFunc(2, 2)
+	assert.Equal(t, "Se*********ta", r("SensitiveData"))
+}
+
+func TestTruncateVisibleFunc_TruncatesWithNoMark(t *testing.T) {
+	t.Parallel()
+	r := mask.TruncateVisibleFunc(3)
+	assert.Equal(t, "abc", r("abcdef"))
+	assert.Equal(t, "", r(""))
+}
+
+func TestPreserveDelimitersFunc_EmptyInput(t *testing.T) {
+	t.Parallel()
+	r := mask.PreserveDelimitersFunc("@.")
+	assert.Equal(t, "", r(""))
+}
+
+// ---------- DeterministicHash ----------
+
+func TestDeterministicHash_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	const v = "alice@example.com"
+	first := mask.DeterministicHash(v)
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, first, mask.DeterministicHash(v))
+	}
+}
+
+func TestDeterministicHash_UsesSHA256_ByDefault(t *testing.T) {
+	t.Parallel()
+	out := mask.DeterministicHash("alice@example.com")
+	assert.True(t, strings.HasPrefix(out, "sha256:"), "got %q", out)
+	assert.Equal(t, len("sha256:")+16, len(out), "expected 23 bytes, got %d", len(out))
+}
+
+func TestDeterministicHash_WithAlgorithm(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		algo   mask.HashAlgorithm
+		prefix string
+	}{
+		{"sha256", mask.SHA256, "sha256"},
+		{"sha512", mask.SHA512, "sha512"},
+		{"sha3_256", mask.SHA3_256, "sha3-256"},
+		{"sha3_512", mask.SHA3_512, "sha3-512"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := mask.DeterministicHashWith("alice@example.com", mask.WithAlgorithm(tc.algo))
+			want := tc.prefix + ":"
+			assert.True(t, strings.HasPrefix(out, want), "got %q, want prefix %q", out, want)
+			assert.Equal(t, len(tc.prefix)+1+16, len(out))
+		})
+	}
+}
+
+func TestDeterministicHash_WithSalt_UsesHMAC(t *testing.T) {
+	t.Parallel()
+	const (
+		val  = "alice@example.com"
+		salt = "k"
+	)
+	cases := []struct {
+		name   string
+		algo   mask.HashAlgorithm
+		ctor   func() hash.Hash
+		prefix string
+	}{
+		{"sha256", mask.SHA256, sha256.New, "sha256"},
+		{"sha512", mask.SHA512, sha512.New, "sha512"},
+		{"sha3_256", mask.SHA3_256, func() hash.Hash { return sha3.New256() }, "sha3-256"},
+		{"sha3_512", mask.SHA3_512, func() hash.Hash { return sha3.New512() }, "sha3-512"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mask.DeterministicHashWith(val, mask.WithAlgorithm(tc.algo), mask.WithSalt(salt))
+			h := hmac.New(tc.ctor, []byte(salt))
+			h.Write([]byte(val))
+			want := tc.prefix + ":" + hex.EncodeToString(h.Sum(nil)[:8])
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestDeterministicHash_WithSalt_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	r := mask.DeterministicHashFunc(mask.WithSalt("k"))
+	first := r("alice@example.com")
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, first, r("alice@example.com"))
+	}
+}
+
+func TestDeterministicHash_DifferentSalt_DifferentOutput(t *testing.T) {
+	t.Parallel()
+	const v = "alice@example.com"
+	a := mask.DeterministicHashWith(v, mask.WithSalt("salt-a"))
+	b := mask.DeterministicHashWith(v, mask.WithSalt("salt-b"))
+	assert.NotEqual(t, a, b)
+}
+
+func TestDeterministicHash_EmptySaltCollapsesToUnsalted(t *testing.T) {
+	t.Parallel()
+	// WithSalt("") must produce the same output as no salt at all.
+	const v = "alice@example.com"
+	withEmpty := mask.DeterministicHashWith(v, mask.WithSalt(""))
+	unsalted := mask.DeterministicHash(v)
+	assert.Equal(t, unsalted, withEmpty)
+}
+
+func TestDeterministicHash_BuiltInEqualsZeroOptionFactory(t *testing.T) {
+	t.Parallel()
+	factory := mask.DeterministicHashFunc()
+	for _, v := range []string{"", "a", "alice@example.com", "佐藤太郎", "\xff\xfe", strings.Repeat("x", 1000), "a\x00b"} {
+		assert.Equal(t, mask.DeterministicHash(v), factory(v), "input=%q", v)
+		assert.Equal(t, mask.DeterministicHash(v), mask.Apply("deterministic_hash", v), "input=%q via Apply", v)
+	}
+}
+
+func TestDeterministicHash_OptionLastWins(t *testing.T) {
+	t.Parallel()
+	// Algorithm: last-wins collapses to SHA-256.
+	out := mask.DeterministicHashWith("x",
+		mask.WithAlgorithm(mask.SHA512),
+		mask.WithAlgorithm(mask.SHA256))
+	assert.True(t, strings.HasPrefix(out, "sha256:"))
+
+	// Salt: WithSalt("k") then WithSalt("") reverts to unsalted.
+	back := mask.DeterministicHashWith("x",
+		mask.WithSalt("k"),
+		mask.WithSalt(""))
+	unsalted := mask.DeterministicHash("x")
+	assert.Equal(t, unsalted, back)
+}
+
+func TestDeterministicHash_UnknownAlgorithmClampsToSHA256(t *testing.T) {
+	t.Parallel()
+	out := mask.DeterministicHashWith("x", mask.WithAlgorithm(mask.HashAlgorithm(99)))
+	assert.True(t, strings.HasPrefix(out, "sha256:"))
+
+	out = mask.DeterministicHashWith("x", mask.WithAlgorithm(mask.HashAlgorithm(-1)))
+	assert.True(t, strings.HasPrefix(out, "sha256:"))
+}
+
+func TestHashAlgorithm_StringMatchesPrefix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		algo mask.HashAlgorithm
+		want string
+	}{
+		{mask.SHA256, "sha256"},
+		{mask.SHA512, "sha512"},
+		{mask.SHA3_256, "sha3-256"},
+		{mask.SHA3_512, "sha3-512"},
+		{mask.HashAlgorithm(99), "sha256"},
+		{mask.HashAlgorithm(-1), "sha256"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.algo.String())
+	}
+}
+
+// TestDeterministicHash_SaltNotLeakedInOutputOrDescribe verifies acceptance
+// criterion #10 (issue #3): salt values never appear in masked output, in
+// Describe(), or in errors.
+//
+// Strategy: cover a corpus of inputs that deliberately includes values equal
+// to the salt, values containing the salt as a substring, and encoded
+// variants. Walk Describe()'s RuleInfo fields reflectively so this test
+// keeps working if RuleInfo gains new string fields.
+func TestDeterministicHash_SaltNotLeakedInOutputOrDescribe(t *testing.T) {
+	t.Parallel()
+	const salt = "SEKRET"
+
+	m := mask.New()
+	require.NoError(t, m.Register("salted_hash", mask.DeterministicHashFunc(mask.WithSalt(salt))))
+
+	inputs := []string{
+		"",
+		"ascii",
+		salt, // value == salt
+		salt + "-with-suffix",
+		"prefix-" + salt,
+		"佐藤太郎",
+		"\xff\xfe",                       // invalid UTF-8
+		"\x00" + salt + "\x00",           // NUL-wrapped salt
+		hex.EncodeToString([]byte(salt)), // hex-encoded form
+		strings.Repeat("x", 1000),
+	}
+	for _, in := range inputs {
+		out := m.Apply("salted_hash", in)
+		assert.NotContains(t, out, salt, "salt leaked for input=%q", in)
+		assert.NotContains(t, out, hex.EncodeToString([]byte(salt)), "salt-hex leaked for input=%q", in)
+	}
+
+	info, ok := m.Describe("salted_hash")
+	require.True(t, ok)
+	v := reflect.ValueOf(info)
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() == reflect.String {
+			assert.NotContains(t, f.String(), salt,
+				"salt leaked in RuleInfo.%s", v.Type().Field(i).Name)
+		}
+	}
+}
+
+func TestDeterministicHash_ConcurrentHashing(t *testing.T) {
+	t.Parallel()
+	r := mask.DeterministicHashFunc(mask.WithSalt("k"))
+	want := r("alice@example.com")
+
+	const goroutines = 50
+	gate := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-gate
+			for j := 0; j < 200; j++ {
+				got := r("alice@example.com")
+				if got != want {
+					errs <- errors.New("mismatch under concurrent use")
+					return
+				}
+			}
+		}()
+	}
+	close(gate)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}
+
+// ---------- Registered primitive Apply paths ----------
+
+func TestApply_RegisteredPrimitives(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	assert.Equal(t, mask.FullRedactMarker, m.Apply("full_redact", "secret"))
+	assert.Equal(t, "*****", m.Apply("same_length_mask", "hello"))
+	assert.Equal(t, "", m.Apply("nullify", "secret"))
+
+	h := m.Apply("deterministic_hash", "alice@example.com")
+	assert.True(t, strings.HasPrefix(h, "sha256:"))
+	assert.Equal(t, len("sha256:")+16, len(h))
+}
+
+func TestApply_SameLengthMask_HonoursInstanceMaskChar(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	assert.Equal(t, "XXXXX", m.Apply("same_length_mask", "hello"))
+}
+
+func TestApply_SameLengthMask_ReflectsLateMaskCharChange(t *testing.T) {
+	// Intentionally NOT t.Parallel — mutates global mask char.
+	t.Cleanup(func() { mask.SetMaskChar(mask.DefaultMaskChar) })
+
+	mask.SetMaskChar('#')
+	assert.Equal(t, "#####", mask.Apply("same_length_mask", "hello"))
+}
+
+// TestPrimitives_NoPanicOnInvalidMaskRune guards the B1 fix: an invalid
+// mask rune (negative value, lone surrogate, above unicode.MaxRune) used
+// to panic the Builder.Grow path via a negative capacity argument. Every
+// primitive that writes the mask rune must survive without panic AND must
+// still produce a masked output — returning the original value would let
+// a rune-validation regression silently leak data.
+func TestPrimitives_NoPanicOnInvalidMaskRune(t *testing.T) {
+	t.Parallel()
+	badRunes := []rune{-1, 0xD800, 0x110000} // negative, lone surrogate, above MaxRune
+
+	for _, bad := range badRunes {
+		t.Run("", func(t *testing.T) {
+			// SameLengthMask: output MUST have the same rune count as the
+			// input (here 6) and MUST NOT be the original value.
+			out := mask.SameLengthMask("secret", bad)
+			assert.NotPanics(t, func() { _ = out })
+			assert.NotEqual(t, "secret", out)
+			assert.NotEmpty(t, out)
+
+			// KeepFirstN: prefix preserved, tail masked and non-empty.
+			out = mask.KeepFirstN("secret", 2, bad)
+			assert.True(t, strings.HasPrefix(out, "se"), "got %q", out)
+			assert.NotEqual(t, "secret", out)
+
+			// KeepLastN: suffix preserved.
+			out = mask.KeepLastN("secret", 2, bad)
+			assert.True(t, strings.HasSuffix(out, "et"), "got %q", out)
+			assert.NotEqual(t, "secret", out)
+
+			// KeepFirstLast: both ends preserved, middle masked.
+			out = mask.KeepFirstLast("hello world", 2, 2, bad)
+			assert.True(t, strings.HasPrefix(out, "he"), "got %q", out)
+			assert.True(t, strings.HasSuffix(out, "ld"), "got %q", out)
+			assert.NotEqual(t, "hello world", out)
+
+			// PreserveDelimiters: delimiter rune kept verbatim.
+			out = mask.PreserveDelimiters("a-b", "-", bad)
+			assert.Contains(t, out, "-", "delimiter lost; got %q", out)
+			assert.NotEqual(t, "a-b", out)
+
+			// ReducePrecision: numeric prefix preserved up to the dot+1 digit.
+			out = mask.ReducePrecision("37.77", 1, bad)
+			assert.True(t, strings.HasPrefix(out, "37.7"), "got %q", out)
+		})
+	}
+
+	// Masker-level check: construct a Masker with an invalid mask rune and
+	// run the same_length_mask registered rule. Output must still be masked.
+	t.Run("masker level", func(t *testing.T) {
+		m := mask.New(mask.WithMaskChar(-1))
+		out := m.Apply("same_length_mask", "hello")
+		assert.NotEqual(t, "hello", out)
+		assert.NotEmpty(t, out)
+	})
+}
+
+// TestPrimitives_InvalidUTF8NoPanic exercises every primitive that processes
+// string contents with a deliberately malformed UTF-8 input. The library's
+// "no panic on any input" contract is easy to break with a future refactor
+// that drops rune-aware handling, so this test pins the behaviour down for
+// the rune-iterating primitives.
+func TestPrimitives_InvalidUTF8NoPanic(t *testing.T) {
+	t.Parallel()
+	const bad = "\xff\xfe\xfd"
+
+	// None of these should panic; we do not assert on output shape because
+	// invalid-UTF-8 semantics are explicitly rune-level (RuneError per bad
+	// byte) and not part of the public contract.
+	assert.NotPanics(t, func() { _ = mask.SameLengthMask(bad, '*') })
+	assert.NotPanics(t, func() { _ = mask.KeepFirstN(bad, 1, '*') })
+	assert.NotPanics(t, func() { _ = mask.KeepLastN(bad, 1, '*') })
+	assert.NotPanics(t, func() { _ = mask.KeepFirstLast(bad, 1, 1, '*') })
+	assert.NotPanics(t, func() { _ = mask.TruncateVisible(bad, 2) })
+	assert.NotPanics(t, func() { _ = mask.PreserveDelimiters(bad, "@", '*') })
+	assert.NotPanics(t, func() { _ = mask.ReducePrecision(bad, 2, '*') })
+	assert.NotPanics(t, func() { _ = mask.DeterministicHash(bad) })
+	assert.NotPanics(t, func() {
+		_ = mask.DeterministicHashWith(bad, mask.WithSalt("k"), mask.WithAlgorithm(mask.SHA3_512))
+	})
+}
+
+// ---------- Helpers ----------
+
+// short renders s as a short printable identifier suitable for use as a
+// subtest name.
+func short(s string) string {
+	if s == "" {
+		return "empty"
+	}
+	if len(s) > 16 {
+		return "len_" + strings.ReplaceAll(strings.ReplaceAll(s[:8], " ", "_"), "\n", "n") + "_trunc"
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, " ", "_"), "\n", "n"), "\t", "t")
+}

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -28,6 +28,14 @@ import (
 
 // TestGodog is the single entry point for the godog BDD suite. It runs every
 // .feature file under tests/bdd/features.
+//
+// Strict mode is MANDATORY and MUST NOT be disabled. When Strict is true,
+// godog fails the suite on any undefined or pending step — silently
+// skipping unimplemented fixtures is the single most common BDD failure
+// mode and we refuse to let it past CI. The CI workflow carries a guard
+// job that greps every BDD entry file for `Strict: true` and fails the
+// build if the flag is missing or set to false. See
+// .github/workflows/ci.yml → bdd-strict-mode-guard.
 func TestGodog(t *testing.T) {
 	suite := godog.TestSuite{
 		ScenarioInitializer: steps.Register,
@@ -36,6 +44,7 @@ func TestGodog(t *testing.T) {
 			Paths:     []string{"features"},
 			Output:    colors.Colored(os.Stdout),
 			Randomize: -1,
+			Strict:    true,
 			TestingT:  t,
 		},
 	}

--- a/tests/bdd/features/primitives.feature
+++ b/tests/bdd/features/primitives.feature
@@ -1,0 +1,192 @@
+@primitives
+Feature: Utility primitives
+  The mask library ships composable building blocks — FullRedact, Nullify,
+  SameLengthMask, KeepFirstN, KeepLastN, KeepFirstLast, PreserveDelimiters,
+  ReplaceRegex, TruncateVisible, DeterministicHash, FixedReplacement, and
+  ReducePrecision. This feature documents the contract every consumer can
+  rely on.
+
+  Scenario Outline: Full redact always returns the constant marker
+    Given a fresh masker
+    When I apply "full_redact" to "<input>"
+    Then the result is "[REDACTED]"
+
+    Examples:
+      | input       |
+      |             |
+      | anything    |
+      | 佐藤太郎     |
+      | ****        |
+
+  Scenario Outline: Same length mask preserves rune count
+    Given a fresh masker with mask character "<char>"
+    When I apply "same_length_mask" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input    | char | expected |
+      | Hello    | *    | *****    |
+      | 佐藤太郎  | *    | ****     |
+      |          | *    |          |
+      | Hello    | X    | XXXXX    |
+
+  Scenario Outline: Keep first N characters (direct helper)
+    When I use KeepFirstN on "<input>" with n <n> and char "<char>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input    | n  | char | expected   |
+      | abcdef   | 0  | *    | ******     |
+      | abcdef   | 3  | *    | abc***     |
+      | abcdef   | 99 | *    | abcdef     |
+      | abcdef   | -1 | *    | ******     |
+      | Müller   | 3  | *    | Mül***     |
+      | 佐藤太郎  | 2  | *    | 佐藤**      |
+      |          | 2  | *    |            |
+
+  Scenario Outline: Keep last N characters (direct helper)
+    When I use KeepLastN on "<input>" with n <n> and char "<char>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input    | n  | char | expected   |
+      | abcdef   | 0  | *    | ******     |
+      | abcdef   | 3  | *    | ***def     |
+      | abcdef   | 99 | *    | abcdef     |
+      | Müller   | 3  | *    | ***ler     |
+      | 佐藤太郎  | 2  | *    | **太郎      |
+
+  Scenario Outline: Keep first and last characters (direct helper)
+    When I use KeepFirstLast on "<input>" with first <first> last <last> and char "<char>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input          | first | last | char | expected       |
+      | SensitiveData  | 4     | 4    | *    | Sens*****Data  |
+      | ABCD           | 2     | 2    | *    | ABCD           |
+      | ABCD           | 3     | 2    | *    | ABCD           |
+      | ABCDE          | 2     | 2    | *    | AB*DE          |
+      | María          | 2     | 1    | *    | Ma**a          |
+      |                | 2     | 2    | *    |                |
+
+  Scenario Outline: Preserve delimiters while masking surrounding runes
+    When I use PreserveDelimiters on "<input>" with delim "<delim>" and char "<char>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | delim | char | expected          |
+      | alice@example.com  | @.    | *    | *****@*******.*** |
+      | 1-800-555-0199     | -     | *    | *-***-***-****    |
+      | abc                |       | *    | ***               |
+      | 佐藤・太郎          | ・    | *    | **・**             |
+
+  Scenario Outline: Replace regex with a valid pattern
+    When I use ReplaceRegex on "<input>" with pattern "<pattern>" and replacement "<replacement>"
+    Then the replace result is "<expected>" and the error is absent
+
+    Examples:
+      | input  | pattern | replacement | expected |
+      | id-42  | \d+     | N           | id-N     |
+      | abc    | z+      | X           | abc      |
+      | abc    | (a)(b)  | $2$1        | bac      |
+      | abc    | b       |             | ac       |
+
+  Scenario: Replace regex with an invalid pattern is rejected
+    When I use ReplaceRegex on "anything" with pattern "[a-" and replacement "X"
+    Then the replace result is empty and the error is present
+
+  Scenario Outline: Truncate visible to N characters
+    When I use TruncateVisible on "<input>" with n <n>
+    Then the result is "<expected>"
+
+    Examples:
+      | input    | n  | expected |
+      | abcdef   | 0  |          |
+      | abcdef   | -1 |          |
+      | abcdef   | 3  | abc      |
+      | abcdef   | 99 | abcdef   |
+      | Müller   | 3  | Mül      |
+
+  Scenario: Deterministic hash is deterministic across invocations
+    Given a fresh masker
+    When I apply "deterministic_hash" to "alice@example.com" 100 times
+    Then every result is identical
+
+  Scenario: Deterministic hash uses SHA-256 by default
+    Given a fresh masker
+    When I apply "deterministic_hash" to "alice@example.com"
+    Then the result starts with "sha256:"
+    And the result has length 23
+
+  Scenario Outline: Deterministic hash emits the selected algorithm prefix
+    When I compute DeterministicHashWith on "alice@example.com" using algorithm "<algo>"
+    Then the result starts with "<prefix>:"
+    And the result has length <length>
+
+    Examples:
+      | algo     | prefix    | length |
+      | SHA256   | sha256    | 23     |
+      | SHA512   | sha512    | 23     |
+      | SHA3_256 | sha3-256  | 25     |
+      | SHA3_512 | sha3-512  | 25     |
+
+  Scenario Outline: Deterministic hash with a salt matches an independent HMAC reference vector
+    When I compute DeterministicHashWith on "hello" using algorithm "<algo>" and salt "k"
+    Then the result is exactly "<expected>"
+
+    Examples:
+      | algo     | expected                  |
+      | SHA256   | sha256:406e4b43f87095aa   |
+      | SHA512   | sha512:86b6102b754ae558   |
+      | SHA3_256 | sha3-256:f3ac848aab5f2471 |
+      | SHA3_512 | sha3-512:f4b5180b78087d99 |
+
+  Scenario: Deterministic hash with different salts produces different outputs
+    When I compute DeterministicHashWith on "alice@example.com" with salt "a"
+    And I also compute DeterministicHashWith on "alice@example.com" with salt "b"
+    Then the two results differ
+
+  Scenario: Deterministic hash salt does not appear in the masked output
+    When I compute DeterministicHashWith on "SEKRET-value-SEKRET" with salt "SEKRET"
+    Then the result does not contain "SEKRET"
+
+  Scenario: Nullify returns an empty string
+    Given a fresh masker
+    When I apply "nullify" to "anything"
+    Then the result is ""
+
+  Scenario Outline: Fixed replacement ignores input
+    When I use FixedReplacementFunc with replacement "<replacement>" on "<input>"
+    Then the result is "<replacement>"
+
+    Examples:
+      | replacement | input    |
+      | N/A         | secret   |
+      | N/A         |          |
+      | [NONE]      | 佐藤太郎  |
+
+  Scenario Outline: Reduce precision for numeric input
+    When I use ReducePrecision on "<input>" with decimals <decimals> and char "<char>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input        | decimals | char | expected    |
+      | 37.7749295   | 2        | *    | 37.77*****  |
+      | -37.7749     | 2        | *    | -37.77**    |
+      | +37.77       | 2        | *    | +37.77      |
+      | 037.70       | 1        | *    | 037.7*      |
+      | 42           | 2        | *    | 42          |
+      | 37.7         | 5        | *    | 37.7        |
+      |              | 2        | *    |             |
+
+  Scenario Outline: Reduce precision falls back for non-numeric input
+    When I use ReducePrecision on "<input>" with decimals 2 and char "*"
+    Then the result is "<expected>"
+
+    Examples:
+      | input       | expected  |
+      | 1.2e5       | *****     |
+      | NaN         | ***       |
+      | Inf         | ***       |
+      | 1.2.3       | *****     |
+      | 37,77       | *****     |

--- a/tests/bdd/steps/primitives_steps.go
+++ b/tests/bdd/steps/primitives_steps.go
@@ -1,0 +1,213 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/axonops/mask"
+)
+
+// toSingleRune returns the single rune of s or an error if s does not have
+// exactly one rune.
+func toSingleRune(s string) (rune, error) {
+	rs := []rune(s)
+	if len(rs) != 1 {
+		return 0, fmt.Errorf("expected a single rune, got %q", s)
+	}
+	return rs[0], nil
+}
+
+func algoFromLabel(label string) (mask.HashAlgorithm, error) {
+	switch label {
+	case "SHA256":
+		return mask.SHA256, nil
+	case "SHA512":
+		return mask.SHA512, nil
+	case "SHA3_256":
+		return mask.SHA3_256, nil
+	case "SHA3_512":
+		return mask.SHA3_512, nil
+	default:
+		return 0, fmt.Errorf("unknown HashAlgorithm label %q", label)
+	}
+}
+
+func (w *World) applyRule(rule, value string) error {
+	m := w.getOrCreate(defaultKey)
+	w.lastResult = m.Apply(rule, value)
+	return nil
+}
+
+func (w *World) applyRuleNTimes(rule, value string, n int) error {
+	m := w.getOrCreate(defaultKey)
+	w.lastResults = make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		w.lastResults = append(w.lastResults, m.Apply(rule, value))
+	}
+	w.lastResult = w.lastResults[0]
+	return nil
+}
+
+func (w *World) useKeepFirstN(v string, n int, ch string) error {
+	r, err := toSingleRune(ch)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.KeepFirstN(v, n, r)
+	return nil
+}
+
+func (w *World) useKeepLastN(v string, n int, ch string) error {
+	r, err := toSingleRune(ch)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.KeepLastN(v, n, r)
+	return nil
+}
+
+func (w *World) useKeepFirstLast(v string, first, last int, ch string) error {
+	r, err := toSingleRune(ch)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.KeepFirstLast(v, first, last, r)
+	return nil
+}
+
+func (w *World) usePreserveDelimiters(v, delim, ch string) error {
+	r, err := toSingleRune(ch)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.PreserveDelimiters(v, delim, r)
+	return nil
+}
+
+func (w *World) useTruncateVisible(v string, n int) error {
+	w.lastResult = mask.TruncateVisible(v, n)
+	return nil
+}
+
+func (w *World) useReplaceRegex(v, pattern, replacement string) error {
+	w.replaceResult, w.replaceErr = mask.ReplaceRegex(v, pattern, replacement)
+	return nil
+}
+
+func (w *World) useFixedReplacement(replacement, v string) error {
+	r := mask.FixedReplacementFunc(replacement)
+	w.lastResult = r(v)
+	return nil
+}
+
+func (w *World) useReducePrecision(v string, decimals int, ch string) error {
+	r, err := toSingleRune(ch)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.ReducePrecision(v, decimals, r)
+	return nil
+}
+
+func (w *World) useDeterministicHashAlgo(v, algoLabel string) error {
+	algo, err := algoFromLabel(algoLabel)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.DeterministicHashWith(v, mask.WithAlgorithm(algo))
+	return nil
+}
+
+func (w *World) useDeterministicHashAlgoSalt(v, algoLabel, salt string) error {
+	algo, err := algoFromLabel(algoLabel)
+	if err != nil {
+		return err
+	}
+	w.lastResult = mask.DeterministicHashWith(v, mask.WithAlgorithm(algo), mask.WithSalt(salt))
+	return nil
+}
+
+func (w *World) useDeterministicHashSalt(v, salt string) error {
+	w.lastResult = mask.DeterministicHashWith(v, mask.WithSalt(salt))
+	return nil
+}
+
+func (w *World) useDeterministicHashSaltSecond(v, salt string) error {
+	w.secondResult = mask.DeterministicHashWith(v, mask.WithSalt(salt))
+	return nil
+}
+
+func (w *World) everyResultIsIdentical() error {
+	if len(w.lastResults) == 0 {
+		return fmt.Errorf("no results captured")
+	}
+	first := w.lastResults[0]
+	for i, r := range w.lastResults {
+		if r != first {
+			return fmt.Errorf("result %d differs from first: %q vs %q", i, r, first)
+		}
+	}
+	return nil
+}
+
+func (w *World) theResultStartsWith(prefix string) error {
+	if !strings.HasPrefix(w.lastResult, prefix) {
+		return fmt.Errorf("expected prefix %q, got %q", prefix, w.lastResult)
+	}
+	return nil
+}
+
+func (w *World) theResultHasLength(n int) error {
+	if len(w.lastResult) != n {
+		return fmt.Errorf("expected length %d, got %d (%q)", n, len(w.lastResult), w.lastResult)
+	}
+	return nil
+}
+
+func (w *World) theResultDoesNotContain(needle string) error {
+	if strings.Contains(w.lastResult, needle) {
+		return fmt.Errorf("result %q unexpectedly contains %q", w.lastResult, needle)
+	}
+	return nil
+}
+
+func (w *World) theTwoResultsDiffer() error {
+	if w.lastResult == w.secondResult {
+		return fmt.Errorf("expected different results, both were %q", w.lastResult)
+	}
+	return nil
+}
+
+func (w *World) replaceResultIsAndErrAbsent(expected string) error {
+	if w.replaceErr != nil {
+		return fmt.Errorf("expected no error, got %v", w.replaceErr)
+	}
+	if w.replaceResult != expected {
+		return fmt.Errorf("expected %q, got %q", expected, w.replaceResult)
+	}
+	return nil
+}
+
+func (w *World) replaceResultEmptyAndErrPresent() error {
+	if w.replaceErr == nil {
+		return fmt.Errorf("expected an error, got nil")
+	}
+	if w.replaceResult != "" {
+		return fmt.Errorf("expected empty result on error, got %q", w.replaceResult)
+	}
+	return nil
+}

--- a/tests/bdd/steps/steps.go
+++ b/tests/bdd/steps/steps.go
@@ -33,6 +33,10 @@ import (
 type World struct {
 	maskers        map[string]*mask.Masker
 	lastResult     string
+	lastResults    []string
+	secondResult   string
+	replaceResult  string
+	replaceErr     error
 	lastError      error
 	lastRules      []string
 	lastDescribe   mask.RuleInfo
@@ -55,8 +59,11 @@ func Register(sc *godog.ScenarioContext) {
 	w := newWorld()
 
 	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
-		w = newWorld()
-		// Reset global state that scenarios may mutate.
+		// World is constructed per-scenario by Register; do not re-assign
+		// here. This hook exists only to reset global state that scenarios
+		// may mutate. If a future change adds a package-level or BeforeAll
+		// binding of the World, isolation will silently break — keep all
+		// World construction inside Register.
 		mask.SetMaskChar(mask.DefaultMaskChar)
 		return ctx, nil
 	})
@@ -76,12 +83,38 @@ func Register(sc *godog.ScenarioContext) {
 	sc.Step(`^I list rules$`, w.listRules)
 
 	sc.Step(`^the result is "([^"]*)"$`, w.theResultIs)
+	sc.Step(`^the result is exactly "([^"]*)"$`, w.theResultIs)
 	sc.Step(`^the registration fails with error kind "([^"]+)"$`, w.registrationFailsWith)
 	sc.Step(`^masker "([^"]+)" has rule "([^"]+)"$`, w.maskerHasRule)
 	sc.Step(`^masker "([^"]+)" does not have rule "([^"]+)"$`, w.maskerDoesNotHaveRule)
 	sc.Step(`^the describe result is present$`, w.describePresent)
 	sc.Step(`^the describe result name is "([^"]+)"$`, w.describeName)
 	sc.Step(`^the listed rules contain, in order, "([^"]+)", "([^"]+)", "([^"]+)"$`, w.listedRulesInOrder)
+
+	// Primitives feature steps — share the World so "a fresh masker" and
+	// "the result is" are defined exactly once for the whole suite.
+	sc.Step(`^I apply "([^"]+)" to "([^"]*)"$`, w.applyRule)
+	sc.Step(`^I apply "([^"]+)" to "([^"]*)" (\d+) times$`, w.applyRuleNTimes)
+	sc.Step(`^I use KeepFirstN on "([^"]*)" with n (-?\d+) and char "([^"]+)"$`, w.useKeepFirstN)
+	sc.Step(`^I use KeepLastN on "([^"]*)" with n (-?\d+) and char "([^"]+)"$`, w.useKeepLastN)
+	sc.Step(`^I use KeepFirstLast on "([^"]*)" with first (-?\d+) last (-?\d+) and char "([^"]+)"$`, w.useKeepFirstLast)
+	sc.Step(`^I use PreserveDelimiters on "([^"]*)" with delim "([^"]*)" and char "([^"]+)"$`, w.usePreserveDelimiters)
+	sc.Step(`^I use TruncateVisible on "([^"]*)" with n (-?\d+)$`, w.useTruncateVisible)
+	sc.Step(`^I use ReplaceRegex on "([^"]*)" with pattern "([^"]*)" and replacement "([^"]*)"$`, w.useReplaceRegex)
+	sc.Step(`^I use FixedReplacementFunc with replacement "([^"]*)" on "([^"]*)"$`, w.useFixedReplacement)
+	sc.Step(`^I use ReducePrecision on "([^"]*)" with decimals (-?\d+) and char "([^"]+)"$`, w.useReducePrecision)
+	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" using algorithm "([^"]+)"$`, w.useDeterministicHashAlgo)
+	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" using algorithm "([^"]+)" and salt "([^"]*)"$`, w.useDeterministicHashAlgoSalt)
+	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" with salt "([^"]*)"$`, w.useDeterministicHashSalt)
+	sc.Step(`^I also compute DeterministicHashWith on "([^"]*)" with salt "([^"]*)"$`, w.useDeterministicHashSaltSecond)
+
+	sc.Step(`^every result is identical$`, w.everyResultIsIdentical)
+	sc.Step(`^the result starts with "([^"]+)"$`, w.theResultStartsWith)
+	sc.Step(`^the result has length (\d+)$`, w.theResultHasLength)
+	sc.Step(`^the result does not contain "([^"]+)"$`, w.theResultDoesNotContain)
+	sc.Step(`^the two results differ$`, w.theTwoResultsDiffer)
+	sc.Step(`^the replace result is "([^"]*)" and the error is absent$`, w.replaceResultIsAndErrAbsent)
+	sc.Step(`^the replace result is empty and the error is present$`, w.replaceResultEmptyAndErrPresent)
 }
 
 func reverse(s string) string {


### PR DESCRIPTION
## Summary

- **Primitives** (issue #3): FullRedact, Nullify, FixedReplacement, SameLengthMask, KeepFirstN/LastN/FirstLast (+ factories), PreserveDelimiters (+ factory), ReplaceRegex (+ factory), TruncateVisible (+ factory), ReducePrecision (+ factory). Every one is unicode-aware, fails closed where applicable, and has both a direct-call helper and — for parametric ones — a factory RuleFunc.
- **Configurable deterministic hash**: `DeterministicHash` / `DeterministicHashWith` / `DeterministicHashFunc` with `WithAlgorithm(SHA256|SHA512|SHA3_256|SHA3_512)` and `WithSalt("...")`. HMAC when salted, bare digest when not. Built-in rule `deterministic_hash` = `DeterministicHashFunc()` with zero options, unchanged output from before this phase.
- **Non-goals section** in `doc.go` documenting why the library does not accept `context.Context` — stdlib strings/strconv/encoding precedent, masking is pure compute, avoids forcing `context.Background()` at every call site. Covered in a separate design review.
- **BDD strict mode** now set explicitly on the godog runner, guarded by a new CI job (`bdd-strict-mode-guard`) that fails any PR that disables it or introduces `@skip`/`@wip`/`@pending` feature tags. Addresses a standing rule.
- **Benchmark baseline** at `bench.txt` (18 benchmarks, all with `b.ReportAllocs()`) to serve as the golden for a future benchstat regression-guard CI job — tracked in #17.

Closes #3.

## Baseline benchmarks

```
BenchmarkFullRedact-8                        1000000000    0.3307 ns/op         0 B/op    0 allocs/op
BenchmarkSameLengthMask_1000-8               365866        3122   ns/op      1024 B/op    1 allocs/op
BenchmarkKeepFirstN_16-8                     22014561      53.94  ns/op        16 B/op    1 allocs/op
BenchmarkKeepFirstN_1000-8                   382159        3257   ns/op      1024 B/op    1 allocs/op
BenchmarkKeepLastN_16-8                      18178408      68.03  ns/op        16 B/op    1 allocs/op
BenchmarkKeepLastN_1000-8                    323806        3692   ns/op      1024 B/op    1 allocs/op
BenchmarkKeepFirstLast_16-8                  20918738      58.03  ns/op        16 B/op    1 allocs/op
BenchmarkKeepFirstLast_1000-8                299095        3972   ns/op      1024 B/op    1 allocs/op
BenchmarkTruncateVisible_16-8                277720428     4.371  ns/op         0 B/op    0 allocs/op
BenchmarkTruncateVisible_1000-8              276125895     4.320  ns/op         0 B/op    0 allocs/op
BenchmarkPreserveDelimiters_Email-8          12818646      93.47  ns/op        24 B/op    1 allocs/op
BenchmarkPreserveDelimitersFunc_Email-8      10956343      109.1  ns/op        24 B/op    1 allocs/op
BenchmarkReplaceRegexFunc_1000-8             44373         25269  ns/op      4635 B/op   11 allocs/op
BenchmarkDeterministicHash_1000-8            2181520       557.1  ns/op      1080 B/op    3 allocs/op
BenchmarkDeterministicHash_Salted_1000-8     1465852       814.1  ns/op      1576 B/op    9 allocs/op
BenchmarkDeterministicHash_SHA512_1000-8     1349864       871.5  ns/op      1112 B/op    3 allocs/op
BenchmarkDeterministicHash_SHA3_256_1000-8   832321        1419   ns/op      1088 B/op    3 allocs/op
BenchmarkReducePrecision_NumericShort-8      32811463      36.47  ns/op        16 B/op    1 allocs/op
BenchmarkReducePrecision_NumericLong-8       346722        3520   ns/op      1024 B/op    1 allocs/op
BenchmarkReducePrecision_Fallback-8          35827980      33.48  ns/op         8 B/op    1 allocs/op
```

## Test plan

- [x] `make check` green locally.
- [x] Unit tests 48 passing, all under `-race`.
- [x] BDD suite 94 scenarios / 231 steps passing in strict mode.
- [x] Coverage: 96.6% on the library package (≥ 95% target).
- [x] test-analyst, code-reviewer (BLOCKING fix applied), security-reviewer, performance-reviewer, go-quality all consulted.
- [x] commit-message-reviewer passed on the commit.
- [ ] CI green across the matrix (verify after push).