### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true
@@ -167,7 +167,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true
@@ -180,7 +180,7 @@ jobs:
         run: make coverage
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v5.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage
           path: coverage.out
@@ -200,7 +200,7 @@ jobs:
             goarch: amd64
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: BDD strict mode guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Verify every godog TestSuite sets Strict=true
         run: |
           set -euo pipefail
@@ -69,7 +69,7 @@ jobs:
     name: No AI attribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Scan commit messages and tracked files for AI-tool references
@@ -139,8 +139,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
@@ -151,7 +151,7 @@ jobs:
       - name: Vet
         run: make vet
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9.2.0
         with:
           version: v2.11.4
           install-mode: goinstall
@@ -166,8 +166,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
@@ -180,7 +180,7 @@ jobs:
         run: make coverage
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5.0.1
         with:
           name: coverage
           path: coverage.out
@@ -199,8 +199,8 @@ jobs:
           - goos: windows
             goarch: amd64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
@@ -215,8 +215,8 @@ jobs:
     name: Security scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
@@ -229,12 +229,12 @@ jobs:
     name: GoReleaser config check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7.0.0
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Inspect Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,24 +69,24 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version: "1.26"
           cache: true
       - name: Dry-run GoReleaser
         if: inputs.dry_run == true
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7.0.0
         with:
           distribution: goreleaser
           version: "~> v2"
           args: release --snapshot --clean
       - name: Publish GoReleaser
         if: inputs.dry_run != true
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7.0.0
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true
@@ -73,7 +73,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
           cache: true


### PR DESCRIPTION
## Summary

GitHub deprecated Node 20 on Actions runners. This PR bumps every action in our workflows to the latest stable major that runs on Node 24, and pins each one to a specific patch tag so Dependabot can keep bumping us forward cleanly.

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v6.0.2` |
| `actions/setup-go` | `v5` | `v6.0.0` |
| `actions/upload-artifact` | `v4` | `v5.0.1` |
| `golangci/golangci-lint-action` | `v7` | `v9.2.0` |
| `goreleaser/goreleaser-action` | `v6` | `v7.0.0` |
| `dependabot/fetch-metadata` | `v2` | `v3.0.0` |

Supersedes dependabot PRs #10, #11, #12, #13, #14 — those bump by floating major (`@v6`, `@v7`, etc.); this PR consolidates them with specific patch pins and also covers `actions/upload-artifact` (which Dependabot did not open a PR for but was still on Node 20).

## Compatibility notes

- `golangci-lint-action@v9` still accepts `version: v2.11.4` and `install-mode: goinstall`; v8 bumped the required golangci-lint to `>= v2.1.0`, which we already satisfy, and v9 only adds opt-in features (`install-only`, module plugin system).
- `goreleaser-action@v7` is a Node 24 bump with no input changes; our `.goreleaser.yml` is `version: 2` and the `version: "~> v2"` arg continues to work.
- `actions/checkout@v6` and `actions/setup-go@v6` are Node 24 bumps with no changes to the inputs we use. Checkout v6 requires runner `>= v2.329.0`, which GitHub-hosted runners already meet.
- `upload-artifact@v5` has the same API we use (`name`, `path`); no breaking change at our call site.
- `dependabot/fetch-metadata@v3` is only a Node 24 runtime bump; `update-type`, `dependency-group`, and `package-ecosystem` outputs are unchanged.

Closes #10
Closes #11
Closes #12
Closes #13
Closes #14

## Test plan

- [ ] `ci.yml` runs green on this PR (all 9 jobs, including `attribution-guard` and `bdd-strict-mode-guard`)
- [ ] `Lint` job succeeds with `golangci-lint-action@v9.2.0`
- [ ] `GoReleaser config check` job succeeds with `goreleaser-action@v7.0.0`
- [ ] `Test` coverage upload succeeds on ubuntu-latest with `upload-artifact@v5.0.1`
- [ ] No Node 20 deprecation warnings appear in the run logs