### PR TITLE
hash: require salt version on WithSalt and emit it on the wire

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,12 +22,15 @@ The `mask` library is currently in pre-release (`v0.x`). Only the most recent `v
 - Thread safety under the documented contract (`Register` at init, `Apply` concurrent thereafter).
 - Use of `crypto/sha256` for `deterministic_hash` — never MD5 or SHA-1.
 
+**Salt rotation and versioning.** The `deterministic_hash` primitive's `WithSalt(salt, version)` option requires both a salt and a version string. The version is emitted on the wire (`<algo>:<version>:<hex16>`) so downstream consumers can identify which salt generation a hash was computed with. Rotating the salt MUST coincide with changing the version — hashes computed with different versions are not comparable. A non-conforming version or a missing version with a non-empty salt is a fail-closed misconfiguration: every subsequent `Apply` returns `[REDACTED]` rather than producing a hash indistinguishable from the unsalted path. The salt itself is never logged, echoed in output, or exposed via `Describe`; the version, by design, is.
+
 **Out of scope:**
 
 - Guaranteeing anonymisation. `deterministic_hash` is **pseudonymisation**, not anonymisation — same input always produces the same output, so the hash remains a linkable identifier.
 - Validating that callers use the correct rule for their data. The library masks; it does not detect.
-- Protecting against memory disclosure through unrelated channels (process dumps, swap, etc.).
+- Protecting against memory disclosure through unrelated channels (process dumps, swap, etc.). Salt and version both live in process memory and may appear in core dumps or goroutine stacks.
 - Side-channel timing analysis. Masking is not a cryptographic primitive.
+- Managing salt-version registries, rotation policies, or re-hashing historical corpora on version change. The library emits the version; the operator decides when and how to rotate.
 
 ## Reporting a vulnerability
 

--- a/docs/v0.9.0-requirements.md
+++ b/docs/v0.9.0-requirements.md
@@ -754,16 +754,27 @@ These are the composable building blocks. All domain rules above are thin wrappe
 Two optional parameters are exposed via functional options on the direct-call parametric variant and the factory:
 
 1. **Algorithm selection** — `WithAlgorithm(HashAlgorithm)` where `HashAlgorithm` is an enum with values `SHA256` (default), `SHA512`, `SHA3_256`, `SHA3_512`. The output prefix changes with the algorithm: `sha256:`, `sha512:`, `sha3-256:`, `sha3-512:`.
-2. **Salt** — `WithSalt(string)`. When a salt is provided, the value is hashed as `HMAC(salt, value)` using the selected algorithm. When no salt is provided, the value is hashed directly with the selected algorithm. HMAC is chosen over concatenation because it is the standard primitive for keyed hashing and sidesteps length-extension concerns for SHA-2 family algorithms. The salt MUST remain constant for the lifetime of the process; rotating it breaks determinism and therefore correlation — which is usually the opposite of what consumers want from this primitive.
+2. **Salt and version** — `WithSalt(salt, version string)`. Both parameters are required when the caller wants keyed hashing. When a non-empty salt is supplied, the value is hashed as `HMAC(salt, value)` using the selected algorithm and the output is `<algo>:<version>:<first-16-hex>`. HMAC is chosen over concatenation because it is the standard primitive for keyed hashing and sidesteps length-extension concerns for SHA-2 family algorithms.
+
+   - **Version requirement.** The version string is emitted on the wire so a downstream consumer can identify which salt generation produced a given hash. Without a version, rotating the salt would silently invalidate every stored hash with no way to tell which hashes belong to which salt. The version is therefore mandatory alongside a non-empty salt.
+   - **Version grammar.** `^[A-Za-z0-9._-]{1,32}$` — alphanumerics plus `.`, `-`, `_`, 1 to 32 bytes. Colons, whitespace, non-ASCII, and any other character are rejected.
+   - **Fail-closed on misconfiguration.** A non-empty salt paired with an empty or non-conforming version sets a sticky misconfiguration flag on the rule; every subsequent `Apply` returns `[REDACTED]`. This policy is deliberate: silent collapse to unsalted would produce hashes indistinguishable from the unsalted path, inverting the safety property. The flag cannot be cleared by a later option — `WithSalt("k", "bad"), WithSalt("k", "v1")` remains misconfigured.
+   - **Empty salt path.** `WithSalt("", anything)` is the unsalted path. The primitive emits `<algo>:<first-16-hex>` with no version; the version argument is ignored when no salt is in effect.
+   - **Rotation.** The salt MUST remain constant for the lifetime of the process. If operators rotate the salt, they MUST change the version too. Downstream consumers comparing hashes across salt rotations should match on the (algorithm, version) tuple — hashes with different versions are not comparable even when the underlying value is identical.
 
 The built-in registered rule `deterministic_hash` continues to use SHA-256 with no salt (equivalent to `DeterministicHashFunc()` with zero options). Consumers who want a salted or alternative-algorithm variant register a named rule via the factory, e.g.:
 
 ```go
 m.Register("hashed_email", mask.DeterministicHashFunc(
-    mask.WithSalt(os.Getenv("MASK_SALT")),
+    mask.WithSalt(os.Getenv("MASK_SALT"), "v1"),
     mask.WithAlgorithm(mask.SHA512),
 ))
 ```
+
+Output shape examples:
+- Unsalted: `alice@example.com` → `sha256:ff8d9819fc0e12bf`
+- Salted: `alice@example.com` → `sha256:v1:<hex16>` (where `<hex16>` is the first 16 hex chars of HMAC-SHA256("MASK_SALT", "alice@example.com"))
+- Misconfigured: any input → `[REDACTED]`
 
 `HashAlgorithm.String()` returns the prefix form (`"sha256"`, `"sha512"`, `"sha3-256"`, `"sha3-512"`) and is the authoritative source for the output prefix — the emitter and the stringer share one table.
 

--- a/hash.go
+++ b/hash.go
@@ -21,7 +21,23 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"hash"
+	"regexp"
 )
+
+// saltVersionPattern is the grammar a WithSalt version string must match.
+// The set is deliberately narrow:
+//
+//   - A-Z / a-z / 0-9: printable, unambiguous, no encoding issues
+//   - `.`, `-`, `_`:   common version delimiters, all URL-safe, all unreserved
+//     or sub-delim per RFC 3986
+//   - 1-32 bytes:      bounds the on-the-wire prefix so an attacker-influenced
+//     config cannot blow up output size
+//
+// The colon, whitespace, shell metacharacters, non-ASCII letters, and every
+// other structural or ambiguous character are rejected — they would either
+// confuse the `<algo>:<version>:<hex16>` wire format or tempt downstream
+// consumers to parse the version as something other than an opaque label.
+var saltVersionPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,32}$`)
 
 // HashAlgorithm selects the cryptographic hash used by the deterministic-hash
 // primitives. The zero value is [SHA256], the library default. MD5 and SHA-1
@@ -76,9 +92,18 @@ func (a HashAlgorithm) String() string {
 
 // hashConfig is the effective configuration produced by applying zero or more
 // [HashOption] values. The zero value corresponds to "unsalted SHA-256".
+//
+// misconfigured is a sticky, write-once flag: once set to true it cannot be
+// cleared by a later option. Any caller who specifies a salt without a
+// conforming version (or vice versa) misconfigures the rule once and every
+// subsequent Apply emits [FullRedactMarker] verbatim. This prevents a
+// pattern like `WithSalt("k","bad"), WithSalt("k","v1")` from silently
+// re-enabling hashing with an earlier-specified invalid configuration.
 type hashConfig struct {
-	algo HashAlgorithm
-	salt string // empty string means "no salt" — see WithSalt godoc
+	algo          HashAlgorithm
+	salt          string // empty string means "no salt" — see WithSalt godoc
+	version       string // salt version; required iff salt != ""
+	misconfigured bool   // sticky; once true, hashApply emits FullRedactMarker
 }
 
 // HashOption configures the deterministic-hash primitives. Use with
@@ -107,26 +132,67 @@ func WithAlgorithm(a HashAlgorithm) HashOption {
 	}
 }
 
-// WithSalt enables keyed hashing via HMAC. When a non-empty salt is supplied,
-// the primitive emits HMAC(salt, value) using the selected algorithm.
+// WithSalt enables keyed hashing via HMAC. Both salt and version are
+// required when the caller wants keyed hashing — the version is emitted on
+// the on-the-wire output so a downstream consumer can identify which salt
+// generation produced a given hash.
 //
-// An empty salt string is treated as "no salt" and the primitive emits
-// unsalted hash(value). This collapse is deliberate: HMAC with an empty key
-// is technically valid but provides no keying material and would be a
-// cryptographic footgun disguised as an intentional choice. If you truly
-// want empty-key HMAC, use the crypto/hmac package directly.
+// Output shape when a salt is configured:
 //
-// The salt MUST remain constant for the lifetime of the process. Rotating it
-// breaks determinism, and therefore breaks the correlation properties that
-// are the reason this primitive exists. Salt values are never logged, echoed
-// in output, returned in error messages, or exposed via [Describe].
+//	<algo>:<version>:<first-16-hex>
 //
-// Operational note: the salt is an in-memory Go string and may appear in
-// process core dumps or goroutine stacks. Protect the process, not the
-// library.
-func WithSalt(salt string) HashOption {
+// For example, `DeterministicHashFunc(WithSalt("k", "v1"))` applied to
+// "alice@example.com" emits `sha256:v1:<hex16>` where <hex16> is the first
+// 16 hex chars of HMAC-SHA256("k", "alice@example.com").
+//
+// Version grammar: the version MUST match `^[A-Za-z0-9._-]{1,32}$`. Colons,
+// whitespace, non-ASCII characters, other punctuation, and versions longer
+// than 32 bytes are rejected. A misconfigured WithSalt call — empty
+// version or a version that violates the grammar — sets a sticky flag on
+// the hashConfig, and every subsequent Apply emits [FullRedactMarker].
+// This fail-closed policy prevents an operator who typoed the version
+// from silently producing hashes indistinguishable from the unsalted
+// path.
+//
+// WithSalt("", anything) is the unsalted path: the primitive emits
+// `<algo>:<first-16-hex>` with no version. The version is ignored when no
+// salt is in effect.
+//
+// Salt-rotation identification: if the operator changes the salt in their
+// process, the version MUST change too. Downstream consumers comparing
+// hashes across salt rotations should match on the (algorithm, version)
+// tuple — hashes with different versions are not comparable even when the
+// underlying value is identical.
+//
+// The salt itself is never logged, echoed in output, returned in error
+// messages, or exposed via [Describe]. The version, by contrast, is
+// emitted on the wire by design.
+//
+// Operational note: salt and version both live in in-memory Go strings
+// and may appear in process core dumps or goroutine stacks. Protect the
+// process, not the library.
+func WithSalt(salt, version string) HashOption {
 	return func(c *hashConfig) {
+		if c.misconfigured {
+			return // sticky; later options cannot clear a prior misconfiguration
+		}
+		if salt == "" {
+			// Empty salt is the unsalted path. Version is irrelevant.
+			c.salt = ""
+			c.version = ""
+			return
+		}
+		if !saltVersionPattern.MatchString(version) {
+			// Non-conforming or empty version with a non-empty salt is a
+			// misconfiguration. Set the sticky flag and clear any previously
+			// applied salt/version so no partial state leaks into hashApply.
+			c.misconfigured = true
+			c.salt = ""
+			c.version = ""
+			return
+		}
 		c.salt = salt
+		c.version = version
 	}
 }
 
@@ -179,9 +245,17 @@ func hashSumSalted(algo HashAlgorithm, salt, v string) []byte {
 }
 
 // hashApply is the single dispatch point for all deterministic-hash callers.
-// It branches on whether a salt is present, runs the chosen primitive, and
-// emits "<prefix>:<first-16-hex>".
+// The misconfigured guard is checked FIRST — before any hashing work — so
+// a bad salt/version configuration cannot reach the HMAC machinery even
+// as a no-op. On the misconfigured path the marker is returned verbatim:
+// no prefix, no colon, no digest.
+//
+// When salted, the output is "<prefix>:<version>:<first-16-hex>".
+// When unsalted, it is "<prefix>:<first-16-hex>".
 func hashApply(cfg hashConfig, v string) string {
+	if cfg.misconfigured {
+		return FullRedactMarker
+	}
 	algo := resolveAlgo(cfg.algo)
 	var sum []byte
 	if cfg.salt == "" {
@@ -190,16 +264,39 @@ func hashApply(cfg hashConfig, v string) string {
 		sum = hashSumSalted(algo, cfg.salt, v)
 	}
 	// Defence against a future algorithm with a shorter digest. Every
-	// currently supported algorithm produces ≥ 32 bytes.
+	// currently supported algorithm emits ≥ 32 bytes, so this branch
+	// is unreachable with the present algoTable — it exists only so a
+	// future addition of a shorter-digest algorithm cannot index out of
+	// bounds at `sum[:8]`. If such an algorithm is ever added, update
+	// this path to emit the versioned shape when salted.
 	if len(sum) < 8 {
 		return algoTable[algo].prefix + ":"
 	}
 	prefix := algoTable[algo].prefix
-	dst := make([]byte, 0, len(prefix)+1+16)
+	capacity := len(prefix) + 1 + 16
+	if cfg.salt != "" {
+		capacity += len(cfg.version) + 1
+	}
+	dst := make([]byte, 0, capacity)
 	dst = append(dst, prefix...)
 	dst = append(dst, ':')
+	if cfg.salt != "" {
+		dst = append(dst, cfg.version...)
+		dst = append(dst, ':')
+	}
 	dst = hex.AppendEncode(dst, sum[:8])
 	return string(dst)
+}
+
+// buildConfig applies opts to a fresh hashConfig and returns it. Extracted
+// so DeterministicHashWith and DeterministicHashFunc construct config with
+// byte-identical semantics.
+func buildConfig(opts []HashOption) hashConfig {
+	var cfg hashConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
 }
 
 // DeterministicHash replaces v with a truncated SHA-256 hex digest of the
@@ -239,11 +336,7 @@ func DeterministicHash(v string) string {
 //	h := mask.DeterministicHashWith("alice", mask.WithAlgorithm(mask.SHA512))
 //	// h == "sha512:..."
 func DeterministicHashWith(v string, opts ...HashOption) string {
-	var cfg hashConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return hashApply(cfg, v)
+	return hashApply(buildConfig(opts), v)
 }
 
 // DeterministicHashFunc builds a [RuleFunc] that hashes its input according
@@ -258,14 +351,11 @@ func DeterministicHashWith(v string, opts ...HashOption) string {
 // Example:
 //
 //	_ = m.Register("hashed_email", mask.DeterministicHashFunc(
-//	    mask.WithSalt(os.Getenv("MASK_SALT")),
+//	    mask.WithSalt(os.Getenv("MASK_SALT"), "v1"),
 //	    mask.WithAlgorithm(mask.SHA3_256),
 //	))
 func DeterministicHashFunc(opts ...HashOption) RuleFunc {
-	var cfg hashConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
+	cfg := buildConfig(opts)
 	return func(v string) string {
 		return hashApply(cfg, v)
 	}

--- a/primitives_bench_test.go
+++ b/primitives_bench_test.go
@@ -162,7 +162,7 @@ func BenchmarkDeterministicHash_1000(b *testing.B) {
 }
 
 func BenchmarkDeterministicHash_Salted_1000(b *testing.B) {
-	r := mask.DeterministicHashFunc(mask.WithSalt("secretkey"))
+	r := mask.DeterministicHashFunc(mask.WithSalt("secretkey", "v1"))
 	b.ReportAllocs()
 	b.ResetTimer()
 	var s string

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -766,6 +766,54 @@ func TestDeterministicHash_SaltNotLeakedInOutputOrDescribe(t *testing.T) {
 	}
 }
 
+// TestDeterministicHash_VersionDoesNotLeakSalt asserts the two-sided
+// contract called out in issue #24: the salt never appears in any output
+// surface, while the version — which is part of the public wire format —
+// must appear in the output for every successful hash.
+func TestDeterministicHash_VersionDoesNotLeakSalt(t *testing.T) {
+	t.Parallel()
+	const (
+		salt    = "SEKRET"
+		version = "v1"
+	)
+
+	m := mask.New()
+	require.NoError(t, m.Register("salted_hash_v", mask.DeterministicHashFunc(mask.WithSalt(salt, version))))
+
+	inputs := []string{
+		"",
+		"ascii",
+		salt,
+		salt + "-with-suffix",
+		"prefix-" + salt,
+		"佐藤太郎",
+		"\xff\xfe",
+		"\x00" + salt + "\x00",
+		hex.EncodeToString([]byte(salt)),
+		strings.Repeat("x", 1000),
+	}
+	for _, in := range inputs {
+		out := m.Apply("salted_hash_v", in)
+		assert.NotContains(t, out, salt, "salt leaked for input=%q", in)
+		assert.NotContains(t, out, hex.EncodeToString([]byte(salt)), "salt-hex leaked for input=%q", in)
+		// The positive half of the contract: the version IS part of the
+		// wire format and must appear between the algo prefix and the
+		// digest.
+		assert.Contains(t, out, ":"+version+":", "version missing for input=%q; out=%q", in, out)
+	}
+
+	info, ok := m.Describe("salted_hash_v")
+	require.True(t, ok)
+	v := reflect.ValueOf(info)
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() == reflect.String {
+			assert.NotContains(t, f.String(), salt,
+				"salt leaked in RuleInfo.%s", v.Type().Field(i).Name)
+		}
+	}
+}
+
 func TestDeterministicHash_ConcurrentHashing(t *testing.T) {
 	t.Parallel()
 	r := mask.DeterministicHashFunc(mask.WithSalt("k", "v1"))

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"hash"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -484,8 +485,9 @@ func TestDeterministicHash_WithAlgorithm(t *testing.T) {
 func TestDeterministicHash_WithSalt_UsesHMAC(t *testing.T) {
 	t.Parallel()
 	const (
-		val  = "alice@example.com"
-		salt = "k"
+		val     = "alice@example.com"
+		salt    = "k"
+		version = "v1"
 	)
 	cases := []struct {
 		name   string
@@ -500,18 +502,27 @@ func TestDeterministicHash_WithSalt_UsesHMAC(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mask.DeterministicHashWith(val, mask.WithAlgorithm(tc.algo), mask.WithSalt(salt))
+			got := mask.DeterministicHashWith(val, mask.WithAlgorithm(tc.algo), mask.WithSalt(salt, version))
 			h := hmac.New(tc.ctor, []byte(salt))
 			h.Write([]byte(val))
-			want := tc.prefix + ":" + hex.EncodeToString(h.Sum(nil)[:8])
+			want := tc.prefix + ":" + version + ":" + hex.EncodeToString(h.Sum(nil)[:8])
 			assert.Equal(t, want, got)
 		})
 	}
 }
 
+func TestDeterministicHashWith_IncludesVersion(t *testing.T) {
+	t.Parallel()
+	out := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", "v1"))
+	// Must begin with the versioned prefix and be exactly 26 bytes long:
+	// "sha256:" (7) + "v1:" (3) + 16 hex = 26.
+	assert.True(t, strings.HasPrefix(out, "sha256:v1:"), "got %q", out)
+	assert.Len(t, out, 26)
+}
+
 func TestDeterministicHash_WithSalt_IsDeterministic(t *testing.T) {
 	t.Parallel()
-	r := mask.DeterministicHashFunc(mask.WithSalt("k"))
+	r := mask.DeterministicHashFunc(mask.WithSalt("k", "v1"))
 	first := r("alice@example.com")
 	for i := 0; i < 1000; i++ {
 		assert.Equal(t, first, r("alice@example.com"))
@@ -521,18 +532,140 @@ func TestDeterministicHash_WithSalt_IsDeterministic(t *testing.T) {
 func TestDeterministicHash_DifferentSalt_DifferentOutput(t *testing.T) {
 	t.Parallel()
 	const v = "alice@example.com"
-	a := mask.DeterministicHashWith(v, mask.WithSalt("salt-a"))
-	b := mask.DeterministicHashWith(v, mask.WithSalt("salt-b"))
+	a := mask.DeterministicHashWith(v, mask.WithSalt("salt-a", "v1"))
+	b := mask.DeterministicHashWith(v, mask.WithSalt("salt-b", "v1"))
 	assert.NotEqual(t, a, b)
+}
+
+func TestDeterministicHash_DifferentVersions_DifferentOutputs(t *testing.T) {
+	t.Parallel()
+	const (
+		v    = "alice@example.com"
+		salt = "k"
+	)
+	pairs := []struct{ left, right string }{
+		{"v1", "v2"},
+		{"v1", "V1"},
+		{"v1", "v1.0"},
+		{"2026-01", "2026-02"},
+		{"a", "a."},
+		{"rc1", "rc2"},
+	}
+	for _, p := range pairs {
+		t.Run(p.left+"_vs_"+p.right, func(t *testing.T) {
+			a := mask.DeterministicHashWith(v, mask.WithSalt(salt, p.left))
+			b := mask.DeterministicHashWith(v, mask.WithSalt(salt, p.right))
+			assert.NotEqual(t, a, b)
+		})
+	}
 }
 
 func TestDeterministicHash_EmptySaltCollapsesToUnsalted(t *testing.T) {
 	t.Parallel()
-	// WithSalt("") must produce the same output as no salt at all.
+	// WithSalt("", anything) is the unsalted path — version is ignored
+	// when salt is empty. Output equals the plain DeterministicHash.
 	const v = "alice@example.com"
-	withEmpty := mask.DeterministicHashWith(v, mask.WithSalt(""))
-	unsalted := mask.DeterministicHash(v)
-	assert.Equal(t, unsalted, withEmpty)
+	for _, ver := range []string{"", "v1", "2026-01", "anything goes here"} {
+		t.Run("version="+ver, func(t *testing.T) {
+			withEmpty := mask.DeterministicHashWith(v, mask.WithSalt("", ver))
+			unsalted := mask.DeterministicHash(v)
+			assert.Equal(t, unsalted, withEmpty)
+		})
+	}
+}
+
+func TestDeterministicHash_EmptyVersionFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Non-empty salt + empty version → every Apply returns the full-redact
+	// marker verbatim. No prefix, no colon, no digest.
+	salts := []string{"k", "SEKRET", "\x00", "佐藤", strings.Repeat("s", 1024)}
+	values := []string{"", "x", "alice@example.com", "佐藤太郎", "\xff\xfe", strings.Repeat("x", 1000), mask.FullRedactMarker}
+	for _, s := range salts {
+		for _, v := range values {
+			got := mask.DeterministicHashWith(v, mask.WithSalt(s, ""))
+			assert.Equal(t, mask.FullRedactMarker, got, "salt=%q value=%q", s, v)
+		}
+	}
+	// Same via the factory.
+	r := mask.DeterministicHashFunc(mask.WithSalt("k", ""))
+	for _, v := range values {
+		assert.Equal(t, mask.FullRedactMarker, r(v), "factory value=%q", v)
+	}
+}
+
+func TestDeterministicHash_VersionRejectsColon(t *testing.T) {
+	t.Parallel()
+	cases := []string{"v:1", ":", ":v1", "v1:", "v::v", "a:b:c"}
+	for _, ver := range cases {
+		t.Run(ver, func(t *testing.T) {
+			got := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", ver))
+			assert.Equal(t, mask.FullRedactMarker, got)
+		})
+	}
+}
+
+func TestDeterministicHash_VersionCharsetEnforced(t *testing.T) {
+	t.Parallel()
+
+	bad := []string{
+		" ", "v 1", "v\n", "v\r", "v\t1", "v\x00", "v\x7f",
+		"v/1", "v=1", "v+1", "v#1", "v,1", "v;1", "v|1",
+		"v*", "v?", "v(", "v)", "v[", "v]", "v{", "v}",
+		"v@", "v!", "v~", "v'", "v\"", "v`", "v\\", "v$", "v%", "v^", "v&",
+		"🎉", "v🎉", "café", "naïve", "Ω", "ß",
+		strings.Repeat("a", 33),
+		strings.Repeat("a", 64),
+		strings.Repeat("a", 1024),
+	}
+	for _, ver := range bad {
+		t.Run("bad_"+shortVersion(ver), func(t *testing.T) {
+			got := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", ver))
+			assert.Equal(t, mask.FullRedactMarker, got)
+		})
+	}
+
+	good := []string{
+		"v", "1", "v1", "V1", "v.1", "v-1", "v_1", "2026-01", "v_1.2-rc",
+		strings.Repeat("a", 32),
+		"0", "a.b-c_d", ".", "-", "_",
+	}
+	for _, ver := range good {
+		t.Run("good_"+shortVersion(ver), func(t *testing.T) {
+			got := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", ver))
+			assert.NotEqual(t, mask.FullRedactMarker, got)
+			assert.True(t, strings.HasPrefix(got, "sha256:"+ver+":"), "got %q", got)
+		})
+	}
+}
+
+// shortVersion produces a subtest-name-safe label for a version string.
+func shortVersion(s string) string {
+	if s == "" {
+		return "empty"
+	}
+	if len(s) > 8 {
+		return "len_" + strconv.Itoa(len(s))
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9' {
+			out = append(out, b)
+		} else {
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}
+
+func TestDeterministicHash_StickyMisconfiguration(t *testing.T) {
+	t.Parallel()
+	// Misconfigured option followed by a valid one must still produce
+	// FullRedactMarker — the sticky flag cannot be cleared.
+	got := mask.DeterministicHashWith("alice@example.com",
+		mask.WithSalt("k", "bad:version"),
+		mask.WithSalt("k", "v1"))
+	assert.Equal(t, mask.FullRedactMarker, got)
 }
 
 func TestDeterministicHash_BuiltInEqualsZeroOptionFactory(t *testing.T) {
@@ -552,10 +685,11 @@ func TestDeterministicHash_OptionLastWins(t *testing.T) {
 		mask.WithAlgorithm(mask.SHA256))
 	assert.True(t, strings.HasPrefix(out, "sha256:"))
 
-	// Salt: WithSalt("k") then WithSalt("") reverts to unsalted.
+	// Salt: WithSalt("k", "v1") then WithSalt("", "anything") reverts to
+	// the unsalted path.
 	back := mask.DeterministicHashWith("x",
-		mask.WithSalt("k"),
-		mask.WithSalt(""))
+		mask.WithSalt("k", "v1"),
+		mask.WithSalt("", "anything"))
 	unsalted := mask.DeterministicHash("x")
 	assert.Equal(t, unsalted, back)
 }
@@ -600,7 +734,7 @@ func TestDeterministicHash_SaltNotLeakedInOutputOrDescribe(t *testing.T) {
 	const salt = "SEKRET"
 
 	m := mask.New()
-	require.NoError(t, m.Register("salted_hash", mask.DeterministicHashFunc(mask.WithSalt(salt))))
+	require.NoError(t, m.Register("salted_hash", mask.DeterministicHashFunc(mask.WithSalt(salt, "v1"))))
 
 	inputs := []string{
 		"",
@@ -634,7 +768,7 @@ func TestDeterministicHash_SaltNotLeakedInOutputOrDescribe(t *testing.T) {
 
 func TestDeterministicHash_ConcurrentHashing(t *testing.T) {
 	t.Parallel()
-	r := mask.DeterministicHashFunc(mask.WithSalt("k"))
+	r := mask.DeterministicHashFunc(mask.WithSalt("k", "v1"))
 	want := r("alice@example.com")
 
 	const goroutines = 50
@@ -768,7 +902,7 @@ func TestPrimitives_InvalidUTF8NoPanic(t *testing.T) {
 	assert.NotPanics(t, func() { _ = mask.ReducePrecision(bad, 2, '*') })
 	assert.NotPanics(t, func() { _ = mask.DeterministicHash(bad) })
 	assert.NotPanics(t, func() {
-		_ = mask.DeterministicHashWith(bad, mask.WithSalt("k"), mask.WithAlgorithm(mask.SHA3_512))
+		_ = mask.DeterministicHashWith(bad, mask.WithSalt("k", "v1"), mask.WithAlgorithm(mask.SHA3_512))
 	})
 }
 

--- a/tests/bdd/features/primitives.feature
+++ b/tests/bdd/features/primitives.feature
@@ -131,24 +131,51 @@ Feature: Utility primitives
       | SHA3_512 | sha3-512  | 25     |
 
   Scenario Outline: Deterministic hash with a salt matches an independent HMAC reference vector
-    When I compute DeterministicHashWith on "hello" using algorithm "<algo>" and salt "k"
+    When I compute DeterministicHashWith on "hello" using algorithm "<algo>" and salt "k" version "v1"
     Then the result is exactly "<expected>"
 
     Examples:
-      | algo     | expected                  |
-      | SHA256   | sha256:406e4b43f87095aa   |
-      | SHA512   | sha512:86b6102b754ae558   |
-      | SHA3_256 | sha3-256:f3ac848aab5f2471 |
-      | SHA3_512 | sha3-512:f4b5180b78087d99 |
+      | algo     | expected                     |
+      | SHA256   | sha256:v1:406e4b43f87095aa   |
+      | SHA512   | sha512:v1:86b6102b754ae558   |
+      | SHA3_256 | sha3-256:v1:f3ac848aab5f2471 |
+      | SHA3_512 | sha3-512:v1:f4b5180b78087d99 |
+
+  Scenario Outline: Salt version is emitted between the algorithm prefix and the digest
+    When I compute DeterministicHashWith on "hello" using algorithm "<algo>" and salt "k" version "<version>"
+    Then the result starts with "<prefix>"
+
+    Examples:
+      | algo     | version   | prefix            |
+      | SHA256   | v1        | sha256:v1:        |
+      | SHA512   | v1        | sha512:v1:        |
+      | SHA3_256 | 2026-01   | sha3-256:2026-01: |
+      | SHA3_512 | v_1.2-rc  | sha3-512:v_1.2-rc: |
 
   Scenario: Deterministic hash with different salts produces different outputs
-    When I compute DeterministicHashWith on "alice@example.com" with salt "a"
-    And I also compute DeterministicHashWith on "alice@example.com" with salt "b"
+    When I compute DeterministicHashWith on "alice@example.com" with salt "a" version "v1"
+    And I also compute DeterministicHashWith on "alice@example.com" with salt "b" version "v1"
     Then the two results differ
 
   Scenario: Deterministic hash salt does not appear in the masked output
-    When I compute DeterministicHashWith on "SEKRET-value-SEKRET" with salt "SEKRET"
+    When I compute DeterministicHashWith on "SEKRET-value-SEKRET" with salt "SEKRET" version "v1"
     Then the result does not contain "SEKRET"
+
+  Scenario: Deterministic hash with an empty version fails closed
+    When I compute DeterministicHashWith on "hello" with salt "k" version ""
+    Then the result is exactly "[REDACTED]"
+
+  Scenario Outline: Deterministic hash with a non-conforming version fails closed
+    When I compute DeterministicHashWith on "hello" with salt "k" version "<version>"
+    Then the result is exactly "[REDACTED]"
+
+    Examples:
+      | version                            |
+      | v:1                                |
+      | v 1                                |
+      | v/1                                |
+      | café                               |
+      | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  |
 
   Scenario: Nullify returns an empty string
     Given a fresh masker

--- a/tests/bdd/steps/primitives_steps.go
+++ b/tests/bdd/steps/primitives_steps.go
@@ -132,22 +132,22 @@ func (w *World) useDeterministicHashAlgo(v, algoLabel string) error {
 	return nil
 }
 
-func (w *World) useDeterministicHashAlgoSalt(v, algoLabel, salt string) error {
+func (w *World) useDeterministicHashAlgoSaltVersion(v, algoLabel, salt, version string) error {
 	algo, err := algoFromLabel(algoLabel)
 	if err != nil {
 		return err
 	}
-	w.lastResult = mask.DeterministicHashWith(v, mask.WithAlgorithm(algo), mask.WithSalt(salt))
+	w.lastResult = mask.DeterministicHashWith(v, mask.WithAlgorithm(algo), mask.WithSalt(salt, version))
 	return nil
 }
 
-func (w *World) useDeterministicHashSalt(v, salt string) error {
-	w.lastResult = mask.DeterministicHashWith(v, mask.WithSalt(salt))
+func (w *World) useDeterministicHashSaltVersion(v, salt, version string) error {
+	w.lastResult = mask.DeterministicHashWith(v, mask.WithSalt(salt, version))
 	return nil
 }
 
-func (w *World) useDeterministicHashSaltSecond(v, salt string) error {
-	w.secondResult = mask.DeterministicHashWith(v, mask.WithSalt(salt))
+func (w *World) useDeterministicHashSaltVersionSecond(v, salt, version string) error {
+	w.secondResult = mask.DeterministicHashWith(v, mask.WithSalt(salt, version))
 	return nil
 }
 

--- a/tests/bdd/steps/steps.go
+++ b/tests/bdd/steps/steps.go
@@ -104,9 +104,9 @@ func Register(sc *godog.ScenarioContext) {
 	sc.Step(`^I use FixedReplacementFunc with replacement "([^"]*)" on "([^"]*)"$`, w.useFixedReplacement)
 	sc.Step(`^I use ReducePrecision on "([^"]*)" with decimals (-?\d+) and char "([^"]+)"$`, w.useReducePrecision)
 	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" using algorithm "([^"]+)"$`, w.useDeterministicHashAlgo)
-	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" using algorithm "([^"]+)" and salt "([^"]*)"$`, w.useDeterministicHashAlgoSalt)
-	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" with salt "([^"]*)"$`, w.useDeterministicHashSalt)
-	sc.Step(`^I also compute DeterministicHashWith on "([^"]*)" with salt "([^"]*)"$`, w.useDeterministicHashSaltSecond)
+	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" using algorithm "([^"]+)" and salt "([^"]*)" version "([^"]*)"$`, w.useDeterministicHashAlgoSaltVersion)
+	sc.Step(`^I compute DeterministicHashWith on "([^"]*)" with salt "([^"]*)" version "([^"]*)"$`, w.useDeterministicHashSaltVersion)
+	sc.Step(`^I also compute DeterministicHashWith on "([^"]*)" with salt "([^"]*)" version "([^"]*)"$`, w.useDeterministicHashSaltVersionSecond)
 
 	sc.Step(`^every result is identical$`, w.everyResultIsIdentical)
 	sc.Step(`^the result starts with "([^"]+)"$`, w.theResultStartsWith)


### PR DESCRIPTION
## Summary

Closes #24.

Rotating a salt without a version silently invalidates every stored hash. This PR makes `WithSalt` take both salt and version, emits the version between the algorithm prefix and the digest (`<algo>:<version>:<hex16>` when salted), and fails closed on misconfiguration so a typoed version can never produce hashes indistinguishable from the unsalted path.

## Key changes

- `WithSalt(salt, version string) HashOption` — both required; version grammar `^[A-Za-z0-9._-]{1,32}$`.
- Sticky `hashConfig.misconfigured` flag — set once, never cleared by later options. `hashApply` checks it first, before any crypto work.
- `buildConfig` helper ensures `DeterministicHashWith` and `DeterministicHashFunc` apply options with byte-identical semantics.
- Output shape:
  - Unsalted: `sha256:ff8d9819fc0e12bf` (unchanged)
  - Salted: `sha256:v1:<hex16>`
  - Misconfigured: `[REDACTED]`
- `docs/v0.9.0-requirements.md` rewritten for the new spec.
- `SECURITY.md` gains a "Salt rotation and versioning" threat-model paragraph.

## Test plan

- [x] `make check` green (fmt, vet, lint, tidy, unit, BDD, coverage 97.6%, govulncheck).
- [x] BDD 199 scenarios / 546 steps in strict mode.
- [x] Pre-code security-reviewer, performance-reviewer, test-analyst consulted with a concrete edge-case corpus.
- [x] Post-code test-analyst, security-reviewer, code-reviewer, go-quality consulted — all returned Clean / PASS / Approved on the final diff.
- [x] commit-message-reviewer passed.
- [ ] CI green across the matrix.