### PR TITLE
feat: add technology domain masking rules (#4)

### DIFF
--- a/rules_technology.go
+++ b/rules_technology.go
@@ -1,0 +1,1166 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"net/url"
+	"strings"
+	"unicode/utf8"
+)
+
+// Technology-category rules implement the 14 masks from
+// docs/v0.9.0-requirements.md §"Technology and Infrastructure".
+// Every rule is fail-closed: malformed input routes to a
+// [SameLengthMask] over the whole value rather than echoing it.
+//
+// Structural rules (url, url_credentials, connection_string) parse
+// with net/url and NEVER emit u.String() or u.User.String() —
+// net/url re-encodes percent sequences and re-orders query keys,
+// which would change output bytes and could leak secrets. The
+// output is rebuilt manually from validated raw fields.
+
+// ---------- file-local constants ----------
+
+// bearerElisionSuffix is the literal trailing marker spec'd for the
+// bearer_token rule. Four mask runes (rendered by the rule) followed
+// by three ASCII periods indicate elision; the three periods are NOT
+// replaced by the configured mask character because they are a
+// format literal, not masked payload.
+const bearerElisionDots = "..."
+
+// passwordMaskRunes is the fixed output length of the password rule
+// — spec'd as "independent of source length".
+const passwordMaskRunes = 8
+
+// bearerSchemePrefix is the exact case-sensitive scheme we recognise.
+// RFC 7235 says the scheme is case-insensitive, but the spec example
+// shows `Bearer` — we fail closed on any other case so a `bearer`
+// lowercase or `BEARER` upper variant routes to same_length_mask and
+// does not produce a partially-masked token.
+const bearerSchemePrefix = "Bearer "
+
+// bearerTokenKeep is the rune count of the token prefix we retain
+// before the elision marker.
+const bearerTokenKeep = 6
+
+// jwtHeaderKeep is the rune count we retain from the JWT header
+// segment before the first `.`.
+const jwtHeaderKeep = 4
+
+// fixedMaskWidth is the rune count used for fixed-width mask blocks
+// that do not track the original value length. Reused across the
+// JWT segment mask, IPv6 hextet mask, URL fragment mask, URL query
+// value mask, and connection-string secret-value mask. Each use is
+// independently a policy choice; they happen to agree today, but
+// the constant name is deliberately generic so changing one does
+// not appear to couple them.
+const fixedMaskWidth = 4
+
+// apiKeyKeepEach is the rune count of the leading and trailing
+// windows preserved on api_key values.
+const apiKeyKeepEach = 4
+
+// secretQueryKeys lists the connection_string query parameter names
+// whose VALUES we redact. Keys match case-insensitively against the
+// lowercase form. Keep narrow — over-matching risks masking
+// structural params consumers rely on.
+var secretQueryKeys = map[string]struct{}{
+	"password":     {},
+	"passwd":       {},
+	"pwd":          {},
+	"apikey":       {},
+	"api_key":      {},
+	"token":        {},
+	"secret":       {},
+	"auth_token":   {},
+	"access_token": {},
+}
+
+// ---------- rune / byte classifiers ----------
+
+func isASCIIDecDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+func isASCIIHexDigit(b byte) bool {
+	return isASCIIDecDigit(b) ||
+		(b >= 'a' && b <= 'f') ||
+		(b >= 'A' && b <= 'F')
+}
+
+// isBase64URLByte reports whether b is a character from the base64url
+// alphabet (RFC 4648 §5). Padding `=` is NOT accepted — JWTs use the
+// unpadded form. Used as a cheap JWT-segment check.
+func isBase64URLByte(b byte) bool {
+	return isASCIIDecDigit(b) ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		b == '-' || b == '_'
+}
+
+// ---------- ipv4_address ----------
+
+// maskIPv4 preserves the first 2 octets, masks the last 2 as single
+// mask runes separated by literal dots. Fail-closed on anything
+// other than a strict dotted quad of ASCII decimal octets ≤ 255.
+func maskIPv4(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	dots, ok := parseIPv4Dots(v)
+	if !ok {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(dots[1] + 2 + 2*safeRuneLen(c))
+	b.WriteString(v[:dots[1]])
+	b.WriteByte('.')
+	b.WriteRune(c)
+	b.WriteByte('.')
+	b.WriteRune(c)
+	return b.String()
+}
+
+// parseIPv4Dots walks v and, if v is a strict dotted quad of ASCII
+// decimal octets ≤ 255, returns the three dot positions and true.
+func parseIPv4Dots(v string) ([3]int, bool) {
+	var dots [3]int
+	dotCount := 0
+	octetStart := 0
+	for i := 0; i < len(v); i++ {
+		b := v[i]
+		if b == '.' {
+			if dotCount == 3 || !validOctet(v[octetStart:i]) {
+				return dots, false
+			}
+			dots[dotCount] = i
+			dotCount++
+			octetStart = i + 1
+			continue
+		}
+		if !isASCIIDecDigit(b) {
+			return dots, false
+		}
+	}
+	if dotCount != 3 || !validOctet(v[octetStart:]) {
+		return dots, false
+	}
+	return dots, true
+}
+
+// validOctet reports whether s is a 1-3 byte ASCII decimal string
+// with value ≤ 255. Caller must have already verified all bytes are
+// ASCII digits.
+func validOctet(s string) bool {
+	if s == "" || len(s) > 3 {
+		return false
+	}
+	return octetInRange(s)
+}
+
+// octetInRange reports whether s is a 1-3 byte ASCII decimal string
+// with value ≤ 255. Caller must have already verified all bytes are
+// ASCII digits.
+func octetInRange(s string) bool {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		n = n*10 + int(s[i]-'0')
+	}
+	return n <= 255
+}
+
+// ---------- ipv6_address ----------
+
+// maskIPv6 preserves the first 4 hextets and masks the remaining
+// hextets as one mask rune × 4 per hextet, separated by `:`. The
+// compressed `::` form is preserved verbatim when the compression
+// is entirely in the tail (i.e. fewer than 4 explicit left
+// hextets): the implicit zeros then effectively fill the first-4
+// preserved region. Inputs containing `.` (IPv4-embedded),
+// `%` (zone ID), or more than one `::` fail closed.
+func maskIPv6(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	// Reject IPv4-embedded and zone IDs up-front — both are valid
+	// IPv6 shapes in the wild but the rule's semantics ("preserve
+	// first 4 hextets") does not extend to them cleanly, and a
+	// partial match here would leak an IPv4 prefix.
+	for i := 0; i < len(v); i++ {
+		b := v[i]
+		if b == '.' || b == '%' {
+			return SameLengthMask(v, c)
+		}
+	}
+	// Find `::` position — there may be at most one.
+	dcIdx := strings.Index(v, "::")
+	if dcIdx >= 0 && strings.Contains(v[dcIdx+2:], "::") {
+		return SameLengthMask(v, c)
+	}
+	if dcIdx < 0 {
+		return maskIPv6Full(v, c)
+	}
+	return maskIPv6Compressed(v, dcIdx, c)
+}
+
+// maskIPv6Full handles the fully-expanded 8-hextet form. All 8
+// colon positions are required; each hextet must be 1-4 ASCII hex
+// chars. Output is `h1:h2:h3:h4:****:****:****:****`.
+func maskIPv6Full(v string, c rune) string {
+	// Count colons; require exactly 7.
+	colons := 0
+	var colonAt [7]int
+	for i := 0; i < len(v); i++ {
+		if v[i] == ':' {
+			if colons == 7 {
+				return SameLengthMask(v, c)
+			}
+			colonAt[colons] = i
+			colons++
+		}
+	}
+	if colons != 7 {
+		return SameLengthMask(v, c)
+	}
+	// Validate each of the 8 hextets.
+	prev := -1
+	for i := 0; i <= 7; i++ {
+		var start, end int
+		if i == 0 {
+			start = 0
+		} else {
+			start = prev + 1
+		}
+		if i == 7 {
+			end = len(v)
+		} else {
+			end = colonAt[i]
+			prev = end
+		}
+		if !isHexHextet(v[start:end]) {
+			return SameLengthMask(v, c)
+		}
+	}
+	// Preserve hextets 0..3 verbatim, mask 4..7.
+	preserveEnd := colonAt[3] // byte index of the 4th colon
+	var b strings.Builder
+	b.Grow(preserveEnd + 4*(1+fixedMaskWidth*safeRuneLen(c)))
+	b.WriteString(v[:preserveEnd])
+	for i := 0; i < 4; i++ {
+		b.WriteByte(':')
+		writeMaskRunes(&b, c, 4)
+	}
+	return b.String()
+}
+
+// maskIPv6Compressed handles the `::`-compressed form. The `::` is
+// preserved verbatim at its original position; the left side (≤ 4
+// hextets, verbatim) is emitted as-is and the right side (each
+// hextet → 4 mask runes) is masked. The right side must be
+// non-empty — a `1::` / `::` input with no right hextets has no
+// mask work to do and so fails closed to avoid echoing the input.
+//
+// Head-compression edge case: when the left side is empty and the
+// right side would occupy positions that include the preserved
+// first-4 band (`::a:b:c:d:e` expands to 0:0:0:a:b:c:d:e — hextet 4
+// is the explicit `a`), we fail closed rather than mask a hextet
+// that the rule's spec semantics say should be preserved.
+func maskIPv6Compressed(v string, dcIdx int, c rune) string {
+	left := v[:dcIdx]
+	right := v[dcIdx+2:]
+	leftCount, leftOK := countHextets(left, 4)
+	if !leftOK || right == "" {
+		return SameLengthMask(v, c)
+	}
+	rightCount, rightOK := countHextets(right, 7)
+	if !rightOK || leftCount+rightCount > 7 {
+		return SameLengthMask(v, c)
+	}
+	// Head-compression: when left is empty and right would reach into
+	// the first-4 preserve band, we cannot honour the spec contract.
+	if leftCount == 0 && rightCount > 4 {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(dcIdx + 2 + rightCount*(1+fixedMaskWidth*safeRuneLen(c)))
+	b.WriteString(v[:dcIdx])
+	b.WriteString("::")
+	for i := 0; i < rightCount; i++ {
+		if i > 0 {
+			b.WriteByte(':')
+		}
+		writeMaskRunes(&b, c, 4)
+	}
+	return b.String()
+}
+
+// countHextets walks s (possibly empty) and returns the hextet count
+// plus ok=true when s is `[hex{1,4}](:hex{1,4})*` with no trailing or
+// internal empty hextet and the count is ≤ max. Empty s returns (0, true)
+// — valid zero-hextet side of a `::`.
+func countHextets(s string, max int) (int, bool) {
+	if s == "" {
+		return 0, true
+	}
+	count := 0
+	for {
+		colon := strings.IndexByte(s, ':')
+		var hex string
+		if colon < 0 {
+			hex = s
+		} else {
+			hex = s[:colon]
+		}
+		if !isHexHextet(hex) {
+			return 0, false
+		}
+		count++
+		if count > max {
+			return 0, false
+		}
+		if colon < 0 {
+			return count, true
+		}
+		s = s[colon+1:]
+		if s == "" {
+			return 0, false
+		}
+	}
+}
+
+// isHexHextet reports whether s is a 1-4 byte ASCII hexadecimal
+// string.
+func isHexHextet(s string) bool {
+	n := len(s)
+	if n == 0 || n > 4 {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if !isASCIIHexDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------- mac_address ----------
+
+// maskMAC preserves the first 3 octets (OUI) and masks the device
+// portion. Accepts `:` or `-` as separator but NOT both mixed. The
+// Cisco dotted form (`AABB.CCDD.EEFF`) is rejected per spec. Case
+// is preserved verbatim on the kept octets.
+func maskMAC(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	sep, ok := validateMACShape(v)
+	if !ok {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(8 + 3*(1+2*safeRuneLen(c)))
+	b.WriteString(v[:8])
+	for i := 0; i < 3; i++ {
+		b.WriteByte(sep)
+		b.WriteRune(c)
+		b.WriteRune(c)
+	}
+	return b.String()
+}
+
+// validateMACShape reports whether v is a canonical MAC address
+// `HH{sep}HH{sep}HH{sep}HH{sep}HH{sep}HH` where sep is `:` or `-`
+// (uniform across all five). Returns the separator byte plus ok.
+func validateMACShape(v string) (byte, bool) {
+	if len(v) != 17 {
+		return 0, false
+	}
+	sep := v[2]
+	if sep != ':' && sep != '-' {
+		return 0, false
+	}
+	for i := 0; i < 6; i++ {
+		base := i * 3
+		if i > 0 && v[base-1] != sep {
+			return 0, false
+		}
+		if !isASCIIHexDigit(v[base]) || !isASCIIHexDigit(v[base+1]) {
+			return 0, false
+		}
+	}
+	return sep, true
+}
+
+// ---------- hostname ----------
+
+// maskHostname preserves the first label and same-length-masks the
+// remaining labels, preserving the `.` separators. Single-label
+// inputs (no dot), leading/trailing/double dots all fail closed to
+// same_length_mask over the whole input — the spec's literal echo
+// of `db-master` is a spec error we've decided to reject in favour
+// of the library-wide fail-closed contract.
+//
+// Note on label mask width: the spec example for
+// `web-01.prod.example.com` is internally inconsistent — it shows
+// 1 mask rune each for `prod` (4 chars) and `example` (7 chars),
+// then 3 mask runes for `com` (3 chars). No single rule fits all
+// three. We treat the `com → ***` case (same-length) as the
+// authoritative signal and mask each remaining label at its
+// original rune count. The resulting output does preserve label
+// lengths, which is a minor information disclosure; consumers
+// concerned about that should register a custom rule that replaces
+// each label with a fixed-width marker.
+func maskHostname(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	firstDot := strings.IndexByte(v, '.')
+	if firstDot <= 0 { // no dot, or leading dot
+		return SameLengthMask(v, c)
+	}
+	// First label must be a valid DNS-style letter/digit/hyphen/
+	// underscore label — spaces, tabs, control bytes, non-ASCII
+	// would otherwise pass through to the output unmasked.
+	if !isLDHLabel(v[:firstDot]) {
+		return SameLengthMask(v, c)
+	}
+	// Walk remaining labels; any empty label (double-dot, trailing
+	// dot) routes to same_length_mask.
+	rest := v[firstDot+1:]
+	// Any empty label (leading, trailing, or double dots) is malformed.
+	if rest == "" || rest[0] == '.' || rest[len(rest)-1] == '.' || strings.Contains(rest, "..") {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	b.WriteString(v[:firstDot])
+	// Emit '.' then each subsequent label masked by rune-length.
+	b.WriteByte('.')
+	labelStart := 0
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == '.' {
+			writeSameLengthMask(&b, rest[labelStart:i], c)
+			b.WriteByte('.')
+			labelStart = i + 1
+		}
+	}
+	writeSameLengthMask(&b, rest[labelStart:], c)
+	return b.String()
+}
+
+// writeSameLengthMask writes rune-count-of-s copies of c into b.
+func writeSameLengthMask(b *strings.Builder, s string, c rune) {
+	writeMaskRunes(b, c, utf8.RuneCountInString(s))
+}
+
+// isLDHLabel reports whether s is a non-empty DNS-style letter-digit-
+// hyphen label plus underscore (LDH + `_`, which internal service
+// names commonly use). We do NOT enforce the RFC 1035 63-byte limit
+// or the no-leading/trailing-hyphen rule — the aim is to reject
+// obviously-non-hostname inputs (spaces, control bytes, non-ASCII),
+// not to validate DNS-resolvability.
+func isLDHLabel(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isLDHByte(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isLDHByte reports whether c is an ASCII letter, digit, hyphen, or
+// underscore — the relaxed-LDH character class for hostname labels.
+func isLDHByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '_'
+}
+
+// ---------- url ----------
+
+// maskURL parses v with net/url, validates that the parse produced a
+// well-formed authority-bearing URL, and emits the scheme and host
+// verbatim alongside a masked path, masked query values, masked
+// fragment, and (belt-and-braces) a redacted userinfo if one was
+// present. If the URL carries no sensitive subcomponents — no
+// userinfo, no path beyond `/`, no query, no fragment — it routes
+// to same_length_mask to honour the fail-closed contract.
+func maskURL(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	u, ok := parseAuthorityURL(v)
+	if !ok {
+		return SameLengthMask(v, c)
+	}
+	path := urlEscapedPath(u)
+	if !urlHasSensitive(u, path) {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	writeURLMasked(&b, u, path, c)
+	return b.String()
+}
+
+// urlHasSensitive reports whether the URL carries any of the
+// subcomponents the `url` rule must mask. An input with no such
+// component is effectively already safe; we fail closed rather
+// than echoing it.
+func urlHasSensitive(u *url.URL, path string) bool {
+	if u.User != nil {
+		return true
+	}
+	if path != "" && path != "/" {
+		return true
+	}
+	return u.RawQuery != "" || u.Fragment != ""
+}
+
+// writeURLMasked emits the masked URL body (everything after the
+// `scheme://`) into b. Assumes urlHasSensitive(u, path) is true.
+func writeURLMasked(b *strings.Builder, u *url.URL, path string, c rune) {
+	b.WriteString(u.Scheme)
+	b.WriteString("://")
+	if u.User != nil {
+		writeUserinfoRedact(b, u.User, c)
+	}
+	b.WriteString(u.Host)
+	if path != "" {
+		writeMaskedURLPath(b, path, c)
+	}
+	if u.RawQuery != "" {
+		b.WriteByte('?')
+		writeMaskedURLQuery(b, u.RawQuery, c)
+	}
+	if u.Fragment != "" {
+		b.WriteByte('#')
+		writeMaskRunes(b, c, fixedMaskWidth)
+	}
+}
+
+// parseAuthorityURL parses v and returns (parsed, true) only when the
+// result is a well-formed authority-bearing URL: non-empty scheme,
+// non-empty validated host, and no opaque part. Shared by the three
+// URL-based rules to keep validation centralised.
+func parseAuthorityURL(v string) (*url.URL, bool) {
+	u, err := url.Parse(v)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.Opaque != "" {
+		return nil, false
+	}
+	if !isCleanAuthority(u.Host) {
+		return nil, false
+	}
+	return u, true
+}
+
+// urlEscapedPath returns the path in its original percent-encoded
+// form. u.EscapedPath() returns RawPath when it was set and is a
+// valid encoding of Path; otherwise it re-encodes Path. Emitting a
+// decoded u.Path directly would leak literal bytes (spaces, `/`, `%`)
+// into the output and could change the number of path segments.
+func urlEscapedPath(u *url.URL) string {
+	return u.EscapedPath()
+}
+
+// isCleanAuthority validates u.Host does not contain stray authority
+// delimiters that net/url may admit on pathological input. IPv6
+// literals are allowed if bracketed exactly once.
+func isCleanAuthority(h string) bool {
+	if h == "" || hostHasStrayByte(h) {
+		return false
+	}
+	if strings.ContainsAny(h, "[]") {
+		return isBracketedIPv6Host(h)
+	}
+	return true
+}
+
+// hostHasStrayByte reports whether h contains bytes that should never
+// appear in a clean authority (they signal that net/url has accepted
+// a malformed URL whose host field is actually something else).
+// Also rejects any non-ASCII byte — emitting raw 0x80+ bytes into
+// the output could produce invalid UTF-8. Consumers that need IDN
+// support should pre-punycode the host before calling.
+func hostHasStrayByte(h string) bool {
+	for i := 0; i < len(h); i++ {
+		b := h[i]
+		if b >= 0x80 {
+			return true
+		}
+		switch b {
+		case '@', '/', '?', '#', '%', ' ', '\t', '\n', '\r':
+			return true
+		}
+	}
+	return false
+}
+
+// isBracketedIPv6Host reports whether h is an `[ipv6]` literal with
+// an optional trailing `:port` — exactly one `[` at the start, one
+// `]`, and no other brackets.
+func isBracketedIPv6Host(h string) bool {
+	if !strings.HasPrefix(h, "[") {
+		return false
+	}
+	closeIdx := strings.IndexByte(h, ']')
+	if closeIdx < 0 {
+		return false
+	}
+	if strings.Count(h, "[") != 1 || strings.Count(h, "]") != 1 {
+		return false
+	}
+	rest := h[closeIdx+1:]
+	return rest == "" || rest[0] == ':'
+}
+
+// writeUserinfoRedact emits `****:****@` when a password is present
+// in the userinfo, `****@` when only a user is. Never emits the
+// original userinfo bytes.
+func writeUserinfoRedact(b *strings.Builder, u *url.Userinfo, c rune) {
+	_, hasPass := u.Password()
+	writeMaskRunes(b, c, 4)
+	if hasPass {
+		b.WriteByte(':')
+		writeMaskRunes(b, c, 4)
+	}
+	b.WriteByte('@')
+}
+
+// writeMaskedURLPath same-length-masks each non-empty path segment,
+// preserving `/` separators and empty segments (so `//a` stays `//*`).
+func writeMaskedURLPath(b *strings.Builder, path string, c rune) {
+	segStart := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] == '/' {
+			if i > segStart {
+				writeSameLengthMask(b, path[segStart:i], c)
+			}
+			b.WriteByte('/')
+			segStart = i + 1
+		}
+	}
+	if segStart < len(path) {
+		writeSameLengthMask(b, path[segStart:], c)
+	}
+}
+
+// writeMaskedURLQuery walks raw (u.RawQuery — bytes as transmitted),
+// preserving key bytes and `&` / `=` structurally; each value
+// becomes a fixed 4-rune mask. Keys with no `=` (bare flags) are
+// emitted verbatim. Values with no key (leading `=`) still mask.
+func writeMaskedURLQuery(b *strings.Builder, raw string, c rune) {
+	pairStart := 0
+	for i := 0; i <= len(raw); i++ {
+		if i == len(raw) || raw[i] == '&' {
+			writeMaskedQueryPair(b, raw[pairStart:i], c)
+			if i < len(raw) {
+				b.WriteByte('&')
+			}
+			pairStart = i + 1
+		}
+	}
+}
+
+// writeMaskedQueryPair emits `key=****` for `key=value` pairs and
+// same-length-masks any bare flag (no `=`) or empty-key pair. Bare
+// flags in particular are treated as potentially-sensitive because
+// there is no structural separator signalling which half (name or
+// value) the operator put the data in.
+func writeMaskedQueryPair(b *strings.Builder, pair string, c rune) {
+	eq := strings.IndexByte(pair, '=')
+	if eq <= 0 {
+		writeSameLengthMask(b, pair, c)
+		return
+	}
+	b.WriteString(pair[:eq+1])
+	writeMaskRunes(b, c, fixedMaskWidth)
+}
+
+// ---------- url_credentials ----------
+
+// maskURLCredentials preserves scheme, host, port, path, query, and
+// fragment verbatim and redacts userinfo only. Fails closed when no
+// userinfo is present — echoing the input would violate the
+// library-wide "never return original" contract.
+func maskURLCredentials(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	u, ok := parseAuthorityURL(v)
+	if !ok || u.User == nil {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	b.WriteString(u.Scheme)
+	b.WriteString("://")
+	writeUserinfoRedact(&b, u.User, c)
+	b.WriteString(u.Host)
+	b.WriteString(urlEscapedPath(u))
+	if u.RawQuery != "" {
+		b.WriteByte('?')
+		b.WriteString(u.RawQuery)
+	}
+	if u.Fragment != "" {
+		b.WriteByte('#')
+		b.WriteString(u.Fragment)
+	}
+	return b.String()
+}
+
+// ---------- api_key ----------
+
+// maskAPIKey preserves the first 4 and last 4 runes and same-length-
+// masks the middle. Input rune count < 9 falls back to
+// same_length_mask. Length is measured in runes (UTF-8 aware) to
+// avoid byte-length shortcuts masking multi-byte prefixes
+// incorrectly.
+func maskAPIKey(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(v) < apiKeyKeepEach*2+1 {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, apiKeyKeepEach, apiKeyKeepEach, c)
+}
+
+// ---------- jwt_token ----------
+
+// maskJWT validates v is a 3-segment dot-separated base64url string
+// with a header ≥ 4 chars, payload ≥ 1 char, signature ≥ 1 char
+// (unsecured JWTs with empty signature are NOT accepted — the
+// spec's illustrative shape is a signed token). Output is
+// `<first4>****.****.****.` — the trailing dot is part of the
+// spec output and intentional.
+func maskJWT(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	d1 := strings.IndexByte(v, '.')
+	if d1 < jwtHeaderKeep {
+		return SameLengthMask(v, c)
+	}
+	rest := v[d1+1:]
+	d2 := strings.IndexByte(rest, '.')
+	if d2 <= 0 {
+		return SameLengthMask(v, c)
+	}
+	sig := rest[d2+1:]
+	if sig == "" || strings.IndexByte(sig, '.') >= 0 {
+		return SameLengthMask(v, c)
+	}
+	header := v[:d1]
+	payload := rest[:d2]
+	if !isBase64URLSeg(header) || !isBase64URLSeg(payload) || !isBase64URLSeg(sig) {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	// first4 of header + 4*mask + "." + 4*mask + "." + 4*mask + "."
+	b.Grow(jwtHeaderKeep + 3*fixedMaskWidth*safeRuneLen(c) + 3)
+	b.WriteString(header[:jwtHeaderKeep])
+	writeMaskRunes(&b, c, fixedMaskWidth)
+	b.WriteByte('.')
+	writeMaskRunes(&b, c, fixedMaskWidth)
+	b.WriteByte('.')
+	writeMaskRunes(&b, c, fixedMaskWidth)
+	b.WriteByte('.')
+	return b.String()
+}
+
+// isBase64URLSeg reports whether s is a non-empty string of
+// base64url bytes (no padding).
+func isBase64URLSeg(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isBase64URLByte(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------- bearer_token ----------
+
+// maskBearerToken preserves the literal `Bearer ` scheme and the
+// first 6 runes of the token, appending `****...` (four mask runes
+// + three ASCII periods) as the elision marker. Case-sensitive
+// scheme match — `bearer` and `BEARER` variants fail closed to
+// avoid partial masking of a possibly-malformed header.
+func maskBearerToken(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !strings.HasPrefix(v, bearerSchemePrefix) {
+		return SameLengthMask(v, c)
+	}
+	token := v[len(bearerSchemePrefix):]
+	tokenRunes := utf8.RuneCountInString(token)
+	if tokenRunes < bearerTokenKeep {
+		return SameLengthMask(v, c)
+	}
+	// Byte offset at rune 6.
+	cutByte := byteOffsetAtRune(token, bearerTokenKeep)
+	var b strings.Builder
+	b.Grow(len(bearerSchemePrefix) + cutByte + fixedMaskWidth*safeRuneLen(c) + len(bearerElisionDots))
+	b.WriteString(bearerSchemePrefix)
+	b.WriteString(token[:cutByte])
+	writeMaskRunes(&b, c, fixedMaskWidth)
+	b.WriteString(bearerElisionDots)
+	return b.String()
+}
+
+// ---------- password ----------
+
+// maskPassword returns 8 copies of the mask character for non-empty
+// input. Empty in, empty out — preserves the library-wide
+// empty-invariance convention; the "independent of source length"
+// spec language is about masking length, not about manufacturing
+// output from nothing.
+func maskPassword(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(passwordMaskRunes * safeRuneLen(c))
+	writeMaskRunes(&b, c, passwordMaskRunes)
+	return b.String()
+}
+
+// ---------- connection_string ----------
+
+// maskConnectionString parses a URL-shaped DSN and emits
+// scheme+host+port+path verbatim, redacts userinfo, and
+// same-length-masks secret query-parameter VALUES (keys in
+// [secretQueryKeys], matched case-insensitively). Non-secret query
+// params are preserved. Fragment is preserved.
+func maskConnectionString(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	u, ok := parseAuthorityURL(v)
+	if !ok || (u.User == nil && !queryHasSecret(u.RawQuery)) {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	b.WriteString(u.Scheme)
+	b.WriteString("://")
+	if u.User != nil {
+		writeUserinfoRedact(&b, u.User, c)
+	}
+	b.WriteString(u.Host)
+	b.WriteString(urlEscapedPath(u))
+	if u.RawQuery != "" {
+		b.WriteByte('?')
+		writeConnStringQuery(&b, u.RawQuery, c)
+	}
+	if u.Fragment != "" {
+		b.WriteByte('#')
+		writeMaskRunes(&b, c, fixedMaskWidth)
+	}
+	return b.String()
+}
+
+// queryHasSecret scans raw for any secret-key pair. Matches the key
+// case-insensitively against [secretQueryKeys].
+func queryHasSecret(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	pairStart := 0
+	for i := 0; i <= len(raw); i++ {
+		if i == len(raw) || raw[i] == '&' {
+			pair := raw[pairStart:i]
+			if eq := strings.IndexByte(pair, '='); eq > 0 {
+				if _, ok := secretQueryKeys[asciiLower(pair[:eq])]; ok {
+					return true
+				}
+			}
+			pairStart = i + 1
+		}
+	}
+	return false
+}
+
+// writeConnStringQuery walks raw and emits each pair with `key=****`
+// for secret keys (matched case-insensitively) and the verbatim
+// pair otherwise. Structure bytes `&`, `=` preserved.
+func writeConnStringQuery(b *strings.Builder, raw string, c rune) {
+	pairStart := 0
+	for i := 0; i <= len(raw); i++ {
+		if i == len(raw) || raw[i] == '&' {
+			writeConnStringPair(b, raw[pairStart:i], c)
+			if i < len(raw) {
+				b.WriteByte('&')
+			}
+			pairStart = i + 1
+		}
+	}
+}
+
+func writeConnStringPair(b *strings.Builder, pair string, c rune) {
+	eq := strings.IndexByte(pair, '=')
+	// Bare flags (no `=`) and empty-key pairs (`=value`) carry no
+	// key/value structure the rule can trust; mask them length-
+	// preservingly rather than echoing bytes whose role is
+	// ambiguous.
+	if eq <= 0 {
+		writeSameLengthMask(b, pair, c)
+		return
+	}
+	key := pair[:eq]
+	if _, ok := secretQueryKeys[asciiLower(key)]; ok {
+		b.WriteString(key)
+		b.WriteByte('=')
+		writeMaskRunes(b, c, fixedMaskWidth)
+		return
+	}
+	b.WriteString(pair)
+}
+
+// asciiLower returns an ASCII-lowercased copy of s, allocating
+// only when at least one byte in [A-Z] is present. Keeps the
+// connection-string query walker zero-alloc on the common all-
+// lowercase case while still correctly handling mixed-case keys.
+func asciiLower(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'A' && s[i] <= 'Z' {
+			buf := []byte(s)
+			for j := i; j < len(buf); j++ {
+				if buf[j] >= 'A' && buf[j] <= 'Z' {
+					buf[j] += 'a' - 'A'
+				}
+			}
+			return string(buf)
+		}
+	}
+	return s
+}
+
+// ---------- database_dsn ----------
+
+// maskDatabaseDSN parses the Go MySQL DSN form
+// `user:password@protocol(addr)/db?params` and redacts userinfo.
+// The parser looks for an `@` immediately followed by a lowercase
+// scheme identifier and `(` — this rules out unencoded `@`
+// characters inside the password. Any ambiguity (no such `@`, or
+// multiple candidates) fails closed.
+func maskDatabaseDSN(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	candidate, ok := findDSNProtocolAt(v)
+	if !ok {
+		return SameLengthMask(v, c)
+	}
+	userinfo := v[:candidate]
+	rest := v[candidate+1:]
+	if userinfo == "" || rest == "" {
+		return SameLengthMask(v, c)
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	writeMaskRunes(&b, c, 4)
+	if strings.IndexByte(userinfo, ':') >= 0 {
+		b.WriteByte(':')
+		writeMaskRunes(&b, c, 4)
+	}
+	b.WriteByte('@')
+	b.WriteString(rest)
+	return b.String()
+}
+
+// findDSNProtocolAt locates the single `@` whose following bytes
+// match `[a-z]+\(`. Returns the `@` byte offset plus ok=true only
+// when exactly one such `@` is present.
+func findDSNProtocolAt(v string) (int, bool) {
+	candidate := -1
+	for i := 0; i < len(v); i++ {
+		if v[i] != '@' || !looksLikeDSNProtocol(v[i+1:]) {
+			continue
+		}
+		if candidate >= 0 {
+			return 0, false
+		}
+		candidate = i
+	}
+	return candidate, candidate >= 0
+}
+
+// looksLikeDSNProtocol reports whether s starts with a well-formed
+// `[a-z]+\([^)]*\)` protocol-and-address block, optionally followed
+// by a `/` (path separator) or end-of-string. This prevents
+// unterminated inputs like `u:p@tcp(abc` from being treated as a
+// valid DSN shape and emitted as pseudo-masked output.
+func looksLikeDSNProtocol(s string) bool {
+	i := 0
+	for i < len(s) && s[i] >= 'a' && s[i] <= 'z' {
+		i++
+	}
+	if i == 0 || i >= len(s) || s[i] != '(' {
+		return false
+	}
+	closeIdx := strings.IndexByte(s[i+1:], ')')
+	if closeIdx < 0 {
+		return false
+	}
+	after := i + 1 + closeIdx + 1
+	return after == len(s) || s[after] == '/'
+}
+
+// ---------- uuid ----------
+
+// maskUUID preserves the first 8 hex runes and last 4 hex runes of
+// a canonical 8-4-4-4-12 UUID. Hyphens must be at exactly bytes 8,
+// 13, 18, 23; all other positions must be ASCII hex. Non-canonical
+// forms (hyphenless, braced, URN-prefixed) fail closed.
+//
+// Hyphen positions are fixed by the format, so emission skips the
+// generic [keepFirstLastNonSepCounted] walker in favour of direct
+// byte-slice writes — roughly 2x faster for this shape.
+func maskUUID(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if len(v) != 36 {
+		return SameLengthMask(v, c)
+	}
+	for i := 0; i < 36; i++ {
+		switch i {
+		case 8, 13, 18, 23:
+			if v[i] != '-' {
+				return SameLengthMask(v, c)
+			}
+		default:
+			if !isASCIIHexDigit(v[i]) {
+				return SameLengthMask(v, c)
+			}
+		}
+	}
+	cl := safeRuneLen(c)
+	var b strings.Builder
+	b.Grow(8 + 4 + 20*cl + 4) // v[:8] + 4 hyphens + 20 masked runes + v[32:]
+	b.WriteString(v[:8])
+	b.WriteByte('-')
+	writeMaskRunes(&b, c, 4)
+	b.WriteByte('-')
+	writeMaskRunes(&b, c, 4)
+	b.WriteByte('-')
+	writeMaskRunes(&b, c, 4)
+	b.WriteByte('-')
+	writeMaskRunes(&b, c, 8)
+	b.WriteString(v[32:])
+	return b.String()
+}
+
+// ---------- registration ----------
+
+// registerTechnologyRules wires every rule in this file against m.
+func registerTechnologyRules(m *Masker) {
+	m.mustRegisterBuiltin("ipv4_address",
+		func(v string) string { return maskIPv4(v, m.maskChar()) },
+		RuleInfo{
+			Name: "ipv4_address", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the first 2 octets and masks the last 2 as single mask runes; fails closed on malformed input. Example: 192.168.1.42 → 192.168.*.*.",
+		})
+	m.mustRegisterBuiltin("ipv6_address",
+		func(v string) string { return maskIPv6(v, m.maskChar()) },
+		RuleInfo{
+			Name: "ipv6_address", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the first 4 hextets and masks the interface identifier; compressed form is preserved when `::` is in the tail. Example: 2001:0db8:85a3:0000:0000:8a2e:0370:7334 → 2001:0db8:85a3:0000:****:****:****:****.",
+		})
+	m.mustRegisterBuiltin("mac_address",
+		func(v string) string { return maskMAC(v, m.maskChar()) },
+		RuleInfo{
+			Name: "mac_address", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the OUI (first 3 octets) and masks the device identifier; accepts `:` and `-` separators. Example: AA:BB:CC:DD:EE:FF → AA:BB:CC:**:**:**.",
+		})
+	m.mustRegisterBuiltin("hostname",
+		func(v string) string { return maskHostname(v, m.maskChar()) },
+		RuleInfo{
+			Name: "hostname", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the first label and same-length-masks the remaining labels; single-label inputs fail closed. Example: web-01.prod.example.com → web-01.****.*******.***.",
+		})
+	m.mustRegisterBuiltin("url",
+		func(v string) string { return maskURL(v, m.maskChar()) },
+		RuleInfo{
+			Name: "url", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves scheme, host, and port; same-length-masks path segments; masks query values and fragment with fixed 4-rune blocks; redacts userinfo defensively. Example: https://example.com/users/42?token=abc → https://example.com/*****/**?token=****.",
+		})
+	m.mustRegisterBuiltin("url_credentials",
+		func(v string) string { return maskURLCredentials(v, m.maskChar()) },
+		RuleInfo{
+			Name: "url_credentials", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves scheme, host, path, query and fragment; redacts userinfo only. Example: https://admin:s3cret@db.example.com/mydb → https://****:****@db.example.com/mydb.",
+		})
+	m.mustRegisterBuiltin("api_key",
+		func(v string) string { return maskAPIKey(v, m.maskChar()) },
+		RuleInfo{
+			Name: "api_key", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the first 4 and last 4 runes and same-length-masks the middle; input shorter than 9 runes fails closed. Example: AKIAIOSFODNN7EXAMPLE → AKIA************MPLE.",
+		})
+	m.mustRegisterBuiltin("jwt_token",
+		func(v string) string { return maskJWT(v, m.maskChar()) },
+		RuleInfo{
+			Name: "jwt_token", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the first 4 runes of the header segment and masks all three segments with fixed 4-rune blocks separated by literal dots; the output ends with a trailing dot. Example: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc → eyJh****.****.****.",
+		})
+	m.mustRegisterBuiltin("bearer_token",
+		func(v string) string { return maskBearerToken(v, m.maskChar()) },
+		RuleInfo{
+			Name: "bearer_token", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the `Bearer ` scheme and the first 6 runes of the token, appending `****...` as the elision marker (four mask runes then three literal dots). Example: Bearer abc123def456 → Bearer abc123****...",
+		})
+	m.mustRegisterBuiltin("password",
+		func(v string) string { return maskPassword(v, m.maskChar()) },
+		RuleInfo{
+			Name: "password", Category: "technology", Jurisdiction: "global",
+			Description: "Emits a fixed 8-rune mask regardless of source length so password length is not leaked; empty input returns empty. Example: MyP@ssw0rd! → ********.",
+		})
+	m.mustRegisterBuiltin("private_key_pem",
+		FullRedact,
+		RuleInfo{
+			Name: "private_key_pem", Category: "technology", Jurisdiction: "global",
+			Description: "Full redact. Private key material must never be partially revealed. Example: -----BEGIN RSA PRIVATE KEY-----... → [REDACTED].",
+		})
+	m.mustRegisterBuiltin("connection_string",
+		func(v string) string { return maskConnectionString(v, m.maskChar()) },
+		RuleInfo{
+			Name: "connection_string", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves scheme, host, port, path and non-secret query parameters; redacts userinfo and the values of known secret query parameters. Example: postgresql://admin:s3cret@db.example.com:5432/myapp → postgresql://****:****@db.example.com:5432/myapp.",
+		})
+	m.mustRegisterBuiltin("database_dsn",
+		func(v string) string { return maskDatabaseDSN(v, m.maskChar()) },
+		RuleInfo{
+			Name: "database_dsn", Category: "technology", Jurisdiction: "global",
+			Description: "Parses the Go MySQL DSN form `user:password@protocol(addr)/db` and redacts userinfo; preserves protocol, address, database and params. Example: user:password@tcp(localhost:3306)/dbname → ****:****@tcp(localhost:3306)/dbname.",
+		})
+	m.mustRegisterBuiltin("uuid",
+		func(v string) string { return maskUUID(v, m.maskChar()) },
+		RuleInfo{
+			Name: "uuid", Category: "technology", Jurisdiction: "global",
+			Description: "Preserves the first 8 and last 4 hex runes of a canonical 8-4-4-4-12 UUID; non-canonical forms fail closed. Example: 550e8400-e29b-41d4-a716-446655440000 → 550e8400-****-****-****-********0000.",
+		})
+}
+
+func init() {
+	builtinRegistrars = append(builtinRegistrars, registerTechnologyRules)
+}

--- a/rules_technology_bench_test.go
+++ b/rules_technology_bench_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/axonops/mask"
+)
+
+var techSink string
+
+// runBench is a tiny helper that centralises the b.ReportAllocs + loop
+// boilerplate so per-rule benchmarks stay single-line.
+func runBench(b *testing.B, rule, in string) {
+	b.Helper()
+	m := mask.New()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = m.Apply(rule, in)
+	}
+	techSink = s
+}
+
+// ---------- ipv4_address ----------
+
+func BenchmarkApply_ipv4_address(b *testing.B)         { runBench(b, "ipv4_address", "192.168.1.42") }
+func BenchmarkApply_ipv4_address_invalid(b *testing.B) { runBench(b, "ipv4_address", "not.an.ip.here") }
+
+// ---------- ipv6_address ----------
+
+func BenchmarkApply_ipv6_address_full(b *testing.B) {
+	runBench(b, "ipv6_address", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+}
+func BenchmarkApply_ipv6_address_compressed(b *testing.B) { runBench(b, "ipv6_address", "fe80::1") }
+func BenchmarkApply_ipv6_address_invalid(b *testing.B) {
+	runBench(b, "ipv6_address", "2001:db8:gggg::1")
+}
+
+// ---------- mac_address ----------
+
+func BenchmarkApply_mac_address(b *testing.B) { runBench(b, "mac_address", "AA:BB:CC:DD:EE:FF") }
+func BenchmarkApply_mac_address_invalid(b *testing.B) {
+	runBench(b, "mac_address", "AA.BB.CC.DD.EE.FF")
+}
+
+// ---------- hostname ----------
+
+func BenchmarkApply_hostname(b *testing.B) { runBench(b, "hostname", "web-01.prod.example.com") }
+func BenchmarkApply_hostname_single_label(b *testing.B) {
+	runBench(b, "hostname", "db-master")
+}
+
+// ---------- url ----------
+
+func BenchmarkApply_url(b *testing.B) {
+	runBench(b, "url", "https://example.com/users/42?token=abc")
+}
+func BenchmarkApply_url_long(b *testing.B) {
+	long := "https://example.com/" + strings.Repeat("seg/", 50) + "?" + strings.Repeat("k=v&", 20) + "end=1"
+	runBench(b, "url", long)
+}
+func BenchmarkApply_url_invalid(b *testing.B) { runBench(b, "url", "not a url") }
+
+// ---------- url_credentials ----------
+
+func BenchmarkApply_url_credentials(b *testing.B) {
+	runBench(b, "url_credentials", "https://admin:s3cret@db.example.com/mydb")
+}
+
+// ---------- api_key ----------
+
+func BenchmarkApply_api_key(b *testing.B) { runBench(b, "api_key", "AKIAIOSFODNN7EXAMPLE") }
+func BenchmarkApply_api_key_long(b *testing.B) {
+	runBench(b, "api_key", "sk_live_"+strings.Repeat("x", 500))
+}
+func BenchmarkApply_api_key_short(b *testing.B) { runBench(b, "api_key", "abc") }
+
+// ---------- jwt_token ----------
+
+func BenchmarkApply_jwt_token(b *testing.B) {
+	runBench(b, "jwt_token", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U")
+}
+func BenchmarkApply_jwt_token_invalid(b *testing.B) { runBench(b, "jwt_token", "not.a.jwt.extra") }
+
+// ---------- bearer_token ----------
+
+func BenchmarkApply_bearer_token(b *testing.B) {
+	runBench(b, "bearer_token", "Bearer abc123def456")
+}
+func BenchmarkApply_bearer_token_unknown_scheme(b *testing.B) {
+	runBench(b, "bearer_token", "Basic dXNlcjpwYXNz")
+}
+
+// ---------- password ----------
+
+func BenchmarkApply_password(b *testing.B)       { runBench(b, "password", "MyP@ssw0rd!") }
+func BenchmarkApply_password_empty(b *testing.B) { runBench(b, "password", "") }
+
+// ---------- private_key_pem ----------
+
+func BenchmarkApply_private_key_pem(b *testing.B) {
+	runBench(b, "private_key_pem", "-----BEGIN RSA PRIVATE KEY-----\nMIIE...")
+}
+
+// ---------- connection_string ----------
+
+func BenchmarkApply_connection_string(b *testing.B) {
+	runBench(b, "connection_string", "postgresql://admin:s3cret@db.example.com:5432/myapp")
+}
+func BenchmarkApply_connection_string_secret_query(b *testing.B) {
+	runBench(b, "connection_string", "postgresql://db.example.com/d?user=u&password=p&sslmode=require")
+}
+
+// ---------- database_dsn ----------
+
+func BenchmarkApply_database_dsn(b *testing.B) {
+	runBench(b, "database_dsn", "user:password@tcp(localhost:3306)/dbname")
+}
+func BenchmarkApply_database_dsn_invalid(b *testing.B) {
+	runBench(b, "database_dsn", "nothing at all like a dsn")
+}
+
+// ---------- uuid ----------
+
+func BenchmarkApply_uuid(b *testing.B) {
+	runBench(b, "uuid", "550e8400-e29b-41d4-a716-446655440000")
+}
+func BenchmarkApply_uuid_invalid(b *testing.B) {
+	runBench(b, "uuid", "550e8400-e29b-41d4-a716-44665544000g")
+}

--- a/rules_technology_test.go
+++ b/rules_technology_test.go
@@ -1,0 +1,586 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/mask"
+)
+
+// ---------- ipv4_address ----------
+
+func TestApply_IPv4Address(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "192.168.1.42", "192.168.*.*"},
+		{"spec rfc1918", "10.0.0.1", "10.0.*.*"},
+		{"empty", "", ""},
+		{"zero address", "0.0.0.0", "0.0.*.*"},
+		{"broadcast", "255.255.255.255", "255.255.*.*"},
+		{"octet out of range fails closed", "999.999.999.999", "***************"},
+		{"three octets fails closed", "192.168.1", "*********"},
+		{"five octets fails closed", "1.2.3.4.5", "*********"},
+		{"trailing dot fails closed", "192.168.1.42.", "*************"},
+		{"leading dot fails closed", ".192.168.1.42", "*************"},
+		{"cidr fails closed", "192.168.1.42/24", "***************"},
+		{"hex fails closed", "0xC0.0xA8.0x01.0x2A", "*******************"},
+		{"non-ascii digit fails closed", "١٩٢.١٦٨.١.٤٢", "************"},
+		{"already masked ip fails closed", "192.168.*.*", "***********"},
+		{"all-star equal length echoes as same-length", "***********", "***********"},
+		{"space embedded fails closed", "192.168. 1.42", "*************"},
+		{"4-digit octet fails closed", "1.2.3.1234", "**********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("ipv4_address", tc.in))
+		})
+	}
+}
+
+func TestApply_IPv4Address_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	assert.Equal(t, "192.168.X.X", m.Apply("ipv4_address", "192.168.1.42"))
+}
+
+// ---------- ipv6_address ----------
+
+func TestApply_IPv6Address(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec full", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:0db8:85a3:0000:****:****:****:****"},
+		{"spec compressed", "fe80::1", "fe80::****"},
+		{"empty", "", ""},
+		{"loopback", "::1", "::****"},
+		{"compressed mid", "2001:db8::1", "2001:db8::****"},
+		{"compressed mid two", "2001:db8::1:2", "2001:db8::****:****"},
+		{"unspecified fails closed", "::", "**"},
+		{"trailing compressed fails closed (no right)", "fe80::", "******"},
+		{"uppercase hex", "FE80::1", "FE80::****"},
+		{"ipv4 embedded fails closed", "::ffff:192.168.1.1", "******************"},
+		{"zone id fails closed", "fe80::1%eth0", "************"},
+		{"two compressions fails closed", "2001::1::1", "**********"},
+		{"hextet too long fails closed", "20011:db8::1", "************"},
+		{"non-hex fails closed", "2001:db8:gggg::1", "****************"},
+		{"nine hextets fails closed", "1:2:3:4:5:6:7:8:9", "*****************"},
+		{"seven hextets fails closed (no ::)", "1:2:3:4:5:6:7", "*************"},
+		{"head compression overflowing preserve band fails closed", "::1:2:3:4:5:6:7", "***************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("ipv6_address", tc.in))
+		})
+	}
+}
+
+func TestApply_IPv6Address_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	assert.Equal(t, "fe80::XXXX", m.Apply("ipv6_address", "fe80::1"))
+}
+
+// ---------- mac_address ----------
+
+func TestApply_MACAddress(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec colon", "AA:BB:CC:DD:EE:FF", "AA:BB:CC:**:**:**"},
+		{"spec hyphen", "AA-BB-CC-DD-EE-FF", "AA-BB-CC-**-**-**"},
+		{"empty", "", ""},
+		{"lowercase", "aa:bb:cc:dd:ee:ff", "aa:bb:cc:**:**:**"},
+		{"mixed case preserved", "Aa:bB:cC:dD:eE:fF", "Aa:bB:cC:**:**:**"},
+		{"mixed separators fails closed", "AA:BB-CC:DD-EE:FF", "*****************"},
+		{"dotted fails closed", "AABB.CCDD.EEFF", "**************"},
+		{"no separators fails closed", "AABBCCDDEEFF", "************"},
+		{"short fails closed", "AA:BB:CC:DD:EE", "**************"},
+		{"non-hex fails closed", "AA:BB:CC:DD:EE:GG", "*****************"},
+		{"all-zero", "00:00:00:00:00:00", "00:00:00:**:**:**"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("mac_address", tc.in))
+		})
+	}
+}
+
+// ---------- hostname ----------
+
+func TestApply_Hostname(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "web-01.prod.example.com", "web-01.****.*******.***"},
+		{"empty", "", ""},
+		{"two labels", "example.com", "example.***"},
+		{"single label fails closed", "db-master", "*********"},
+		{"all-star equal length single-label fails closed", "*********", "*********"},
+		{"trailing dot fails closed", "example.com.", "************"},
+		{"leading dot fails closed", ".example.com", "************"},
+		{"double dot fails closed", "foo..bar", "********"},
+		{"uppercase first label preserved", "WEB-01.PROD.EXAMPLE.COM", "WEB-01.****.*******.***"},
+		{"idn punycode", "xn--bcher-kva.example.com", "xn--bcher-kva.*******.***"},
+		{"numeric first label", "42.example.com", "42.*******.***"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("hostname", tc.in))
+		})
+	}
+}
+
+// ---------- url ----------
+
+func TestApply_URL_SecurityPins(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	// Pin behaviour that a security review would otherwise catch as
+	// a regression. All of these check that secret-bearing bytes
+	// never pass through to the output unmasked.
+	cases := []struct{ name, in, want string }{
+		{"percent-encoded path preserves shape", "https://example.com/a%20b", "https://example.com/*****"},
+		{"percent-encoded slash does not split segment", "https://example.com/a%2Fb", "https://example.com/*****"},
+		{"trailing slash", "https://example.com/foo/", "https://example.com/***/"},
+		{"double slash path", "https://example.com//a", "https://example.com//*"},
+		{"bare-flag query is masked not echoed", "https://example.com/?AKIAIOSFODNN7EXAMPLE", "https://example.com/?********************"},
+		{"empty-key query is masked", "https://example.com/?=secretvalue", "https://example.com/?************"},
+		{"zone id in host fails closed", "https://[fe80::1%25eth0]/path", "*****************************"},
+		{"non-ascii in host fails closed", "https://example\xffcom/x", "*********************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("url", tc.in))
+		})
+	}
+}
+
+func TestApply_URL(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "https://example.com/users/42?token=abc", "https://example.com/*****/**?token=****"},
+		{"spec localhost port", "http://localhost:8080/api/v1", "http://localhost:8080/***/**"},
+		{"empty", "", ""},
+		{"no sensitive parts fails closed", "https://example.com", "*******************"},
+		{"root path only fails closed", "https://example.com/", "********************"},
+		{"userinfo defensively redacted", "https://alice:secret@example.com/path", "https://****:****@example.com/****"},
+		{"userinfo user only", "https://alice@example.com/path", "https://****@example.com/****"},
+		{"query only", "https://example.com?k=v", "https://example.com?k=****"},
+		{"fragment only", "https://example.com#section", "https://example.com#****"},
+		{"multiple query values", "https://example.com/?a=1&b=2&c=3", "https://example.com/?a=****&b=****&c=****"},
+		{"bare query flag masked", "https://example.com/?flag", "https://example.com/?****"},
+		{"malformed fails closed", "not a url", "*********"},
+		{"data url fails closed", "data:text/plain,hello", "*********************"},
+		{"ipv6 host", "https://[2001:db8::1]:8080/path", "https://[2001:db8::1]:8080/****"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("url", tc.in))
+		})
+	}
+}
+
+// ---------- url_credentials ----------
+
+func TestApply_ConnectionString_SecurityPins(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"case-insensitive secret key", "postgresql://db.example.com/d?Password=secret", "postgresql://db.example.com/d?Password=****"},
+		{"all-caps secret key", "postgresql://db.example.com/d?PASSWORD=secret", "postgresql://db.example.com/d?PASSWORD=****"},
+		{"bare flag masked when any secret present", "postgresql://db.example.com/d?password=x&SENSITIVE_FLAG", "postgresql://db.example.com/d?password=****&**************"},
+		{"empty key pair masked", "postgresql://u:p@db.example.com/d?=secretvalue", "postgresql://****:****@db.example.com/d?************"},
+		{"fragment masked", "postgresql://u:p@db.example.com/d#readonly", "postgresql://****:****@db.example.com/d#****"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("connection_string", tc.in))
+		})
+	}
+}
+
+func TestApply_URLCredentials(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "https://admin:s3cret@db.example.com/mydb", "https://****:****@db.example.com/mydb"},
+		{"empty", "", ""},
+		{"no userinfo fails closed", "https://db.example.com/mydb", "***************************"},
+		{"user only", "https://alice@example.com/mydb", "https://****@example.com/mydb"},
+		{"preserves path verbatim", "https://u:p@example.com/secret/data", "https://****:****@example.com/secret/data"},
+		{"preserves query verbatim", "https://u:p@example.com/?token=abc", "https://****:****@example.com/?token=abc"},
+		{"malformed fails closed", "nope", "****"},
+		{"ipv6 host", "https://u:p@[2001:db8::1]/mydb", "https://****:****@[2001:db8::1]/mydb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("url_credentials", tc.in))
+		})
+	}
+}
+
+// ---------- api_key ----------
+
+func TestApply_APIKey(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec stripe-like", "sk_live_abc123def456ghi789", "sk_l******************i789"},
+		{"spec aws", "AKIAIOSFODNN7EXAMPLE", "AKIA************MPLE"},
+		{"empty", "", ""},
+		{"length exactly eight fails closed", "12345678", "********"},
+		{"length nine keeps endpoints", "123456789", "1234*6789"},
+		{"short fails closed", "x", "*"},
+		{"four fails closed", "1234", "****"},
+		{"unicode prefix preserved", "🔑🔑🔑🔑1234567890", "🔑🔑🔑🔑******7890"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("api_key", tc.in))
+		})
+	}
+}
+
+// ---------- jwt_token ----------
+
+func TestApply_JWT(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	canonical := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", canonical, "eyJh****.****.****."},
+		{"empty", "", ""},
+		{"two segments fails closed", "aaaa.bbbb", "*********"},
+		{"four segments fails closed", "aaaa.bbbb.cccc.dddd", "*******************"},
+		{"header shorter than four fails closed", "ey.payload.sig", "**************"},
+		{"empty payload fails closed", "eyJh..sig", "*********"},
+		{"empty signature fails closed", "eyJh.payload.", "*************"},
+		{"non-base64url fails closed", "eyJh.pay@load.sig", "*****************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("jwt_token", tc.in))
+		})
+	}
+}
+
+// ---------- bearer_token ----------
+
+func TestApply_BearerToken(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec jwt", "Bearer eyJhbGciOiJIUzI1NiJ9.xxx.yyy", "Bearer eyJhbG****..."},
+		{"spec opaque", "Bearer abc123def456", "Bearer abc123****..."},
+		{"empty", "", ""},
+		{"short token fails closed", "Bearer abc", "**********"},
+		{"wrong scheme fails closed", "Basic dXNlcjpwYXNz", "******************"},
+		{"lowercase scheme fails closed", "bearer abcdef123", "****************"},
+		{"no scheme fails closed", "abc123def456", "************"},
+		{"empty token after scheme fails closed", "Bearer ", "*******"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("bearer_token", tc.in))
+		})
+	}
+}
+
+// ---------- password ----------
+
+func TestApply_Password(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "MyP@ssw0rd!", "********"},
+		{"spec single rune", "x", "********"},
+		{"empty preserves empty", "", ""},
+		{"unicode", "メトホルミン", "********"},
+		{"length is eight regardless", strings.Repeat("a", 500), "********"},
+		{"already masked", "********", "********"},
+		{"nul byte", "\x00", "********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("password", tc.in))
+		})
+	}
+}
+
+func TestApply_Password_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	assert.Equal(t, "XXXXXXXX", m.Apply("password", "MyP@ssw0rd!"))
+	// Configured mask char is honoured on empty input — stays empty.
+	assert.Equal(t, "", m.Apply("password", ""))
+}
+
+// ---------- private_key_pem ----------
+
+func TestApply_PrivateKeyPEM(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in string }{
+		{"spec canonical", "-----BEGIN RSA PRIVATE KEY-----\nMIIE..."},
+		{"empty is still full redact", ""},
+		{"garbage input", "\xff\xfe\xfd"},
+		{"very long", strings.Repeat("A", 10000)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, "[REDACTED]", m.Apply("private_key_pem", tc.in))
+		})
+	}
+}
+
+// ---------- connection_string ----------
+
+func TestApply_ConnectionString(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec postgres", "postgresql://admin:s3cret@db.example.com:5432/myapp", "postgresql://****:****@db.example.com:5432/myapp"},
+		{"spec mongo srv", "mongodb+srv://user:pass@cluster.mongodb.net/db", "mongodb+srv://****:****@cluster.mongodb.net/db"},
+		{"empty", "", ""},
+		{"no userinfo or secrets fails closed", "postgresql://db.example.com:5432/myapp", "**************************************"},
+		{"user only", "postgresql://u@db.example.com/d", "postgresql://****@db.example.com/d"},
+		{"secret query only", "postgresql://db.example.com/d?password=secret", "postgresql://db.example.com/d?password=****"},
+		{"non-secret query preserved", "postgresql://u:p@db.example.com/d?sslmode=verify-full", "postgresql://****:****@db.example.com/d?sslmode=verify-full"},
+		{"mixed query", "postgresql://db.example.com/d?user=u&password=p&sslmode=require", "postgresql://db.example.com/d?user=u&password=****&sslmode=require"},
+		{"malformed fails closed", "not a connection string", "***********************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("connection_string", tc.in))
+		})
+	}
+}
+
+// ---------- database_dsn ----------
+
+func TestApply_DatabaseDSN(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "user:password@tcp(localhost:3306)/dbname", "****:****@tcp(localhost:3306)/dbname"},
+		{"empty", "", ""},
+		{"unix socket", "user:pass@unix(/tmp/mysql.sock)/dbname", "****:****@unix(/tmp/mysql.sock)/dbname"},
+		{"with params", "user:pass@tcp(host:3306)/db?parseTime=true&loc=Local", "****:****@tcp(host:3306)/db?parseTime=true&loc=Local"},
+		{"user only", "user@tcp(host)/db", "****@tcp(host)/db"},
+		{"no protocol fails closed", "user:pass@host/db", "*****************"},
+		{"malformed fails closed", "nope", "****"},
+		{"ambiguous multiple @protocol fails closed", "u@tcp(x)/d@tcp(y)/e", "*******************"},
+		{"at-sign in password disambiguated", "u:p@ss@tcp(host:3306)/db", "****:****@tcp(host:3306)/db"},
+		{"unterminated protocol fails closed", "u:p@tcp(", "********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("database_dsn", tc.in))
+		})
+	}
+}
+
+// ---------- uuid ----------
+
+func TestApply_UUID(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "550e8400-e29b-41d4-a716-446655440000", "550e8400-****-****-****-********0000"},
+		{"empty", "", ""},
+		{"uppercase preserved", "550E8400-E29B-41D4-A716-446655440000", "550E8400-****-****-****-********0000"},
+		{"nil uuid", "00000000-0000-0000-0000-000000000000", "00000000-****-****-****-********0000"},
+		{"hyphenless fails closed", "550e8400e29b41d4a716446655440000", "********************************"},
+		{"braced fails closed", "{550e8400-e29b-41d4-a716-446655440000}", "**************************************"},
+		{"wrong length fails closed", "550e8400-e29b-41d4-a716-44665544000", "***********************************"},
+		{"non-hex fails closed", "550e8400-e29b-41d4-a716-44665544000g", "************************************"},
+		{"hyphen wrong position fails closed", "550e84-00e29b-41d4-a716-446655440000", "************************************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("uuid", tc.in))
+		})
+	}
+}
+
+// TestTechnology_MaskCharOverride confirms every rule that emits mask
+// runes honours the per-instance mask character. One representative
+// input per rule.
+func TestTechnology_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	cases := []struct{ rule, in, want string }{
+		{"ipv4_address", "192.168.1.42", "192.168.X.X"},
+		{"ipv6_address", "fe80::1", "fe80::XXXX"},
+		{"mac_address", "AA:BB:CC:DD:EE:FF", "AA:BB:CC:XX:XX:XX"},
+		{"hostname", "web-01.prod.example.com", "web-01.XXXX.XXXXXXX.XXX"},
+		{"url", "https://example.com/users/42?token=abc", "https://example.com/XXXXX/XX?token=XXXX"},
+		{"url_credentials", "https://admin:s3cret@db.example.com/mydb", "https://XXXX:XXXX@db.example.com/mydb"},
+		{"api_key", "AKIAIOSFODNN7EXAMPLE", "AKIAXXXXXXXXXXXXMPLE"},
+		// JWT: trailing dot is a literal format token, NOT the mask
+		// character — stays as `.` regardless of WithMaskChar.
+		{"jwt_token", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig", "eyJhXXXX.XXXX.XXXX."},
+		// Bearer: trailing `...` is a literal elision marker, NOT the
+		// mask character — stays as literal `...` regardless.
+		{"bearer_token", "Bearer abc123def456", "Bearer abc123XXXX..."},
+		{"connection_string", "postgresql://admin:s3cret@db.example.com:5432/myapp", "postgresql://XXXX:XXXX@db.example.com:5432/myapp"},
+		{"database_dsn", "user:password@tcp(localhost:3306)/dbname", "XXXX:XXXX@tcp(localhost:3306)/dbname"},
+		{"uuid", "550e8400-e29b-41d4-a716-446655440000", "550e8400-XXXX-XXXX-XXXX-XXXXXXXX0000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply(tc.rule, tc.in))
+		})
+	}
+}
+
+// ---------- registrations and metadata ----------
+
+func TestDescribe_TechnologyRules(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	names := []string{
+		"ipv4_address", "ipv6_address", "mac_address", "hostname",
+		"url", "url_credentials", "api_key", "jwt_token", "bearer_token",
+		"password", "private_key_pem", "connection_string", "database_dsn", "uuid",
+	}
+	for _, n := range names {
+		t.Run(n, func(t *testing.T) {
+			info, ok := m.Describe(n)
+			require.True(t, ok, "rule %q not registered", n)
+			assert.Equal(t, "technology", info.Category)
+			assert.NotEmpty(t, info.Jurisdiction)
+			assert.NotEmpty(t, info.Description)
+			assert.Equal(t, n, info.Name)
+			assert.Contains(t, info.Description, "Example:",
+				"rule %q description must include an Example", n)
+		})
+	}
+}
+
+// TestTechnology_FailClosedOnMalformed confirms every rule either
+// falls back to SameLengthMask or (for full-redact rules) returns
+// the constant marker, never echoing an obviously-malformed input.
+func TestTechnology_FailClosedOnMalformed(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	malformed := "not-a-valid-anything-of-any-kind-xx"
+	// api_key is parserless — any input ≥ 9 runes gets keep-first-last
+	// masking, so "malformed" is not a meaningful concept for that rule.
+	structuralRules := []string{
+		"ipv4_address", "ipv6_address", "mac_address", "hostname",
+		"url", "url_credentials", "jwt_token", "bearer_token",
+		"connection_string", "database_dsn", "uuid",
+	}
+	for _, n := range structuralRules {
+		t.Run(n, func(t *testing.T) {
+			got := m.Apply(n, malformed)
+			assert.NotEqual(t, malformed, got, "rule %q echoed malformed input", n)
+			assert.Equal(t, strings.Repeat("*", utf8.RuneCountInString(malformed)), got,
+				"rule %q did not produce same-length mask on malformed input", n)
+		})
+	}
+	// Full-redact rules.
+	assert.Equal(t, "[REDACTED]", m.Apply("private_key_pem", malformed))
+	// password masks to fixed 8.
+	assert.Equal(t, "********", m.Apply("password", malformed))
+}
+
+// TestTechnology_NoPanicOnAdversarialInput mirrors the health
+// category's contract: every rule must handle adversarial bytes
+// without panicking and must emit well-formed UTF-8.
+func TestTechnology_NoPanicOnAdversarialInput(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	adversarial := []string{
+		"",
+		"\xff\xfe\xfd",
+		"\x00",
+		strings.Repeat("x", 1000),
+		"https://\x00example.com/",
+		"https://u:p@[2001:db8::\u202E]/x",
+		"\u200Bhttps://example.com/",
+	}
+	names := []string{
+		"ipv4_address", "ipv6_address", "mac_address", "hostname",
+		"url", "url_credentials", "api_key", "jwt_token", "bearer_token",
+		"password", "private_key_pem", "connection_string", "database_dsn", "uuid",
+	}
+	for _, n := range names {
+		for _, in := range adversarial {
+			var got string
+			assert.NotPanics(t, func() { got = m.Apply(n, in) },
+				"rule %q panicked on input %q", n, in)
+			assert.True(t, utf8.ValidString(got),
+				"rule %q produced invalid UTF-8 for input %q: %q", n, in, got)
+		}
+	}
+}
+
+// TestTechnology_IdempotencyMatrix pins, per rule, whether applying
+// the rule to its own output yields the same output. Regressions in
+// either direction surface bugs.
+func TestTechnology_IdempotencyMatrix(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	idempotent := []struct {
+		name, in string
+	}{
+		{"hostname", "web-01.prod.example.com"},
+		{"url", "https://example.com/users/42?token=abc"},
+		{"url_credentials", "https://admin:s3cret@db.example.com/mydb"},
+		{"api_key", "AKIAIOSFODNN7EXAMPLE"},
+		{"bearer_token", "Bearer abc123def456"},
+		{"password", "MyP@ssw0rd!"},
+		{"private_key_pem", "-----BEGIN RSA PRIVATE KEY-----\nMIIE..."},
+		{"connection_string", "postgresql://admin:s3cret@db.example.com:5432/myapp"},
+		{"database_dsn", "user:password@tcp(localhost:3306)/dbname"},
+	}
+	for _, tc := range idempotent {
+		t.Run(tc.name+"/idempotent", func(t *testing.T) {
+			first := m.Apply(tc.name, tc.in)
+			second := m.Apply(tc.name, first)
+			assert.Equal(t, first, second, "rule %q was expected to be idempotent", tc.name)
+		})
+	}
+	// Non-idempotent rules: applying to own output routes to
+	// SameLengthMask because the mask rune is not a valid input token
+	// for the rule's parser.
+	nonIdempotent := []struct {
+		name, in string
+	}{
+		{"ipv4_address", "192.168.1.42"},
+		{"ipv6_address", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+		{"mac_address", "AA:BB:CC:DD:EE:FF"},
+		{"jwt_token", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig"},
+		{"uuid", "550e8400-e29b-41d4-a716-446655440000"},
+	}
+	for _, tc := range nonIdempotent {
+		t.Run(tc.name+"/non-idempotent", func(t *testing.T) {
+			first := m.Apply(tc.name, tc.in)
+			second := m.Apply(tc.name, first)
+			assert.NotEqual(t, first, second,
+				"rule %q was expected to NOT be idempotent (output collapses to same-length mask)", tc.name)
+		})
+	}
+}

--- a/tests/bdd/features/technology.feature
+++ b/tests/bdd/features/technology.feature
@@ -1,0 +1,244 @@
+@technology
+Feature: Technology and infrastructure masking rules
+  The technology category covers the 14 rules documented in
+  docs/v0.9.0-requirements.md §"Technology and Infrastructure".
+  Identifier rules (IP, MAC, UUID) preserve the structural prefix
+  and mask the variable tail; content rules (URL, JWT, DSN)
+  parse the input and mask only sensitive subcomponents; secret
+  rules (password, private_key_pem) use a fixed-shape or full
+  redaction independent of input length.
+
+  Scenario Outline: Mask IPv4 addresses
+    Given a fresh masker
+    When I apply "ipv4_address" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input           | expected         |
+      | 192.168.1.42    | 192.168.*.*      |
+      | 10.0.0.1        | 10.0.*.*         |
+      | 0.0.0.0         | 0.0.*.*          |
+      | 255.255.255.255 | 255.255.*.*      |
+      | 192.168.1       | *********        |
+      | 999.999.999.999 | ***************  |
+      |                 |                  |
+
+  Scenario: IPv4 rule honours per-instance mask character
+    Given a fresh masker with mask character "X"
+    When I apply "ipv4_address" to "192.168.1.42"
+    Then the result is "192.168.X.X"
+
+  Scenario Outline: Mask IPv6 addresses
+    Given a fresh masker
+    When I apply "ipv6_address" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                   | expected                                |
+      | 2001:0db8:85a3:0000:0000:8a2e:0370:7334 | 2001:0db8:85a3:0000:****:****:****:**** |
+      | fe80::1                                 | fe80::****                              |
+      | ::1                                     | ::****                                  |
+      | 2001:db8::1:2                           | 2001:db8::****:****                     |
+      | fe80::1%eth0                            | ************                            |
+      | ::ffff:192.168.1.1                      | ******************                      |
+      |                                         |                                         |
+
+  Scenario Outline: Mask MAC addresses
+    Given a fresh masker
+    When I apply "mac_address" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input             | expected            |
+      | AA:BB:CC:DD:EE:FF | AA:BB:CC:**:**:**   |
+      | AA-BB-CC-DD-EE-FF | AA-BB-CC-**-**-**   |
+      | aa:bb:cc:dd:ee:ff | aa:bb:cc:**:**:**   |
+      | AA:BB-CC:DD-EE:FF | *****************   |
+      | AABB.CCDD.EEFF    | **************      |
+      | AABBCCDDEEFF      | ************        |
+      |                   |                     |
+
+  Scenario Outline: Mask hostnames
+    # Single-label hostnames fail closed — the spec's literal echo
+    # of `db-master` contradicts the library's fail-closed contract,
+    # and we've chosen to honour the contract. Label mask width is
+    # same-length (matches the `com → ***` branch of the spec).
+    Given a fresh masker
+    When I apply "hostname" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                   | expected                |
+      | web-01.prod.example.com | web-01.****.*******.*** |
+      | example.com             | example.***             |
+      | db-master               | *********               |
+      | .example.com            | ************            |
+      | example.com.            | ************            |
+      | foo..bar                | ********                |
+      |                         |                         |
+
+  Scenario Outline: Mask URLs
+    # Path segments are same-length-masked; query values get a
+    # fixed 4-rune mask regardless of their length; fragments
+    # get a fixed 4-rune mask. URLs with no sensitive components
+    # (no userinfo, no path beyond `/`, no query, no fragment)
+    # fail closed to avoid echoing the input.
+    Given a fresh masker
+    When I apply "url" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                   | expected                                |
+      | https://example.com/users/42?token=abc  | https://example.com/*****/**?token=****  |
+      | http://localhost:8080/api/v1            | http://localhost:8080/***/**            |
+      | https://example.com#section             | https://example.com#****                |
+      | https://alice:secret@example.com/path   | https://****:****@example.com/****      |
+      | https://example.com                     | *******************                     |
+      | not a url                               | *********                               |
+      |                                         |                                         |
+
+  Scenario Outline: Mask URL credentials only
+    Given a fresh masker
+    When I apply "url_credentials" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                    | expected                                |
+      | https://admin:s3cret@db.example.com/mydb | https://****:****@db.example.com/mydb   |
+      | https://alice@example.com/mydb           | https://****@example.com/mydb           |
+      | https://db.example.com/mydb              | ***************************             |
+      |                                          |                                         |
+
+  Scenario Outline: Mask API keys
+    Given a fresh masker
+    When I apply "api_key" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                      | expected                   |
+      | AKIAIOSFODNN7EXAMPLE       | AKIA************MPLE       |
+      | sk_live_abc123def456ghi789 | sk_l******************i789 |
+      | 12345678                   | ********                   |
+      | 123456789                  | 1234*6789                  |
+      |                            |                            |
+
+  Scenario Outline: Mask JWT tokens
+    # The spec output ends with a trailing dot — this is a literal
+    # format token, not a sentence terminator.
+    Given a fresh masker
+    When I apply "jwt_token" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                                                                        | expected                |
+      | eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U | eyJh****.****.****.     |
+      | eyJh.payload.sig                                                                             | eyJh****.****.****.     |
+      | aaaa.bbbb                                                                                    | *********               |
+      | eyJh.pay@load.sig                                                                            | *****************       |
+      |                                                                                              |                         |
+
+  Scenario Outline: Mask bearer tokens
+    # Output ends with literal `****...` (four mask runes then three
+    # ASCII dots), a constant elision marker regardless of token
+    # length.
+    Given a fresh masker
+    When I apply "bearer_token" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                               | expected                   |
+      | Bearer abc123def456                 | Bearer abc123****...       |
+      | Bearer eyJhbGciOiJIUzI1NiJ9.xxx.yyy | Bearer eyJhbG****...       |
+      | Bearer abc                          | **********                 |
+      | Basic dXNlcjpwYXNz                  | ******************         |
+      | bearer abcdef123                    | ****************           |
+      |                                     |                            |
+
+  Scenario Outline: Mask passwords
+    Given a fresh masker
+    When I apply "password" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input       | expected |
+      | MyP@ssw0rd! | ******** |
+      | x           | ******** |
+      |             |          |
+
+  Scenario: Password rule honours per-instance mask character
+    Given a fresh masker with mask character "X"
+    When I apply "password" to "MyP@ssw0rd!"
+    Then the result is "XXXXXXXX"
+
+  Scenario Outline: Full-redact private keys
+    Given a fresh masker
+    When I apply "private_key_pem" to "<input>"
+    Then the result is "[REDACTED]"
+
+    Examples:
+      | input                                 |
+      | -----BEGIN RSA PRIVATE KEY-----\nMIIE |
+      |                                       |
+      | garbage input                         |
+
+  Scenario Outline: Mask connection strings
+    Given a fresh masker
+    When I apply "connection_string" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                                              | expected                                                           |
+      | postgresql://admin:s3cret@db.example.com:5432/myapp                | postgresql://****:****@db.example.com:5432/myapp                   |
+      | mongodb+srv://user:pass@cluster.mongodb.net/db                     | mongodb+srv://****:****@cluster.mongodb.net/db                     |
+      | postgresql://db.example.com/d?password=secret                      | postgresql://db.example.com/d?password=****                        |
+      | postgresql://db.example.com/d?user=u&password=p&sslmode=require    | postgresql://db.example.com/d?user=u&password=****&sslmode=require |
+      | postgresql://db.example.com:5432/myapp                             | **************************************                             |
+      |                                                                    |                                                                    |
+
+  Scenario Outline: Mask Go MySQL DSNs
+    Given a fresh masker
+    When I apply "database_dsn" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                    | expected                                 |
+      | user:password@tcp(localhost:3306)/dbname | ****:****@tcp(localhost:3306)/dbname     |
+      | user:pass@unix(/tmp/mysql.sock)/dbname   | ****:****@unix(/tmp/mysql.sock)/dbname   |
+      | user@tcp(host)/db                        | ****@tcp(host)/db                        |
+      | user:pass@host/db                        | *****************                        |
+      |                                          |                                          |
+
+  Scenario Outline: Mask UUIDs
+    Given a fresh masker
+    When I apply "uuid" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input                                | expected                             |
+      | 550e8400-e29b-41d4-a716-446655440000 | 550e8400-****-****-****-********0000 |
+      | 550E8400-E29B-41D4-A716-446655440000 | 550E8400-****-****-****-********0000 |
+      | 00000000-0000-0000-0000-000000000000 | 00000000-****-****-****-********0000 |
+      | 550e8400e29b41d4a716446655440000     | ********************************     |
+      |                                      |                                      |
+
+  Scenario Outline: Every technology rule handles empty input consistently
+    Given a fresh masker
+    When I apply "<rule>" to ""
+    Then the result is "<expected>"
+
+    Examples:
+      | rule              | expected   |
+      | ipv4_address      |            |
+      | ipv6_address      |            |
+      | mac_address       |            |
+      | hostname          |            |
+      | url               |            |
+      | url_credentials   |            |
+      | api_key           |            |
+      | jwt_token         |            |
+      | bearer_token      |            |
+      | password          |            |
+      | private_key_pem   | [REDACTED] |
+      | connection_string |            |
+      | database_dsn      |            |
+      | uuid              |            |


### PR DESCRIPTION
## Summary

Implements the 14 rules from `docs/v0.9.0-requirements.md` §"Technology and Infrastructure": `ipv4_address`, `ipv6_address`, `mac_address`, `hostname`, `url`, `url_credentials`, `connection_string`, `database_dsn`, `api_key`, `jwt_token`, `bearer_token`, `password`, `private_key_pem`, `uuid`.

- **Fail-closed throughout**: every rule routes malformed input to `SameLengthMask` (or `FullRedact` for `private_key_pem`).
- **URL family is leak-hardened**: never emits `u.String()` or `u.User.String()`, rebuilds output from validated raw fields, uses `u.EscapedPath()` to preserve percent-encoding, rejects hosts with stray bytes (`@ / ? # % \s` and any non-ASCII), masks bare query flags and empty-key pairs, masks the fragment on `connection_string`, and redacts userinfo defensively on `url` even though the dedicated rule is `url_credentials`.
- **DSN parser** requires a well-formed `[a-z]+\([^)]*\)` block followed by `/` or end-of-string; ambiguous inputs with multiple candidate `@protocol(` positions fail closed.
- **IPv6 compressed form** preserved verbatim in tail-compression, fail-closed when head-compression would straddle the preserved first-4 hextet band.

## Spec inconsistencies resolved by explicit policy (documented in code comments)

- `url` path segments same-length; query values fixed 4 stars (user decision).
- `api_key` same-length `first4 + middle + last4` (user decision).
- `password` empty-in/empty-out, non-empty → 8 mask runes (user decision).
- `hostname` single-label fails closed rather than echoing (user decision).
- `hostname` label mask width is same-length for consistency with the spec's `com → ***` branch.
- `url` rule masks userinfo defensively if present (user decision).

## Test plan

- [x] `make check` clean: vet, golangci-lint 0 issues, race tests, BDD strict mode, 97.5% coverage, govulncheck 0 affecting vulns.
- [x] Per-rule unit tables covering spec canonical, spec variants, empty, fallback, unicode, already-masked.
- [x] Cross-cutting matrices: `TestTechnology_FailClosedOnMalformed`, `TestTechnology_NoPanicOnAdversarialInput` (UTF-8 validity asserted on every output), `TestTechnology_IdempotencyMatrix`, `TestTechnology_MaskCharOverride` (one input per rule).
- [x] Security regression pins: percent-encoded paths, zone-id hosts, bare-flag query leaks, DSN unterminated-protocol leaks, head-compression IPv6, connection-string case-insensitive secret keys and fragment masking.
- [x] Benchmarks for hot paths (IP/MAC/UUID at 1 alloc/op, password non-empty 1 alloc/op, `private_key_pem` 0 alloc/op) plus fallback/invalid variants.
- [x] Reviewed by test-analyst, code-reviewer, security-reviewer, performance-reviewer, go-quality. Every BLOCKING finding applied to this PR per the fix-don't-defer rule.

Partial progress on #4 (technology subset). Remaining subsets: telecom, country.