### PR TITLE
feat: add telecom and location masking rules (#4)

### DIFF
--- a/primitives.go
+++ b/primitives.go
@@ -342,6 +342,26 @@ func ReducePrecisionFunc(decimals int) RuleFunc {
 	}
 }
 
+// writeReducePrecision is the builder-sink variant of [ReducePrecision] used
+// by [maskGeoCoordinates] to avoid a per-half allocation when assembling the
+// combined lat,lon result. The caller MUST ensure v passes [isGeoMaskable] (or
+// an equivalent pre-check): v is a valid plain decimal with a fractional
+// portion at least decimals+1 digits long so that at least one digit will be
+// masked. Passing an invalid or too-short v violates the precondition and
+// produces garbage output; this is acceptable because the only caller
+// (maskGeoCoordinates) guards with isGeoMaskable before calling.
+func writeReducePrecision(b *strings.Builder, v string, decimals int, c rune) {
+	// isGeoMaskable guarantees a single '.' exists and that cut < len(v),
+	// so the loops below always have work to do.
+	dot := strings.IndexByte(v, '.')
+	cut := dot + 1 + decimals
+	tail := len(v) - cut
+	b.WriteString(v[:cut])
+	for i := 0; i < tail; i++ {
+		b.WriteRune(c)
+	}
+}
+
 // KeepFirstNFunc returns a [RuleFunc] that keeps the first n runes, masking
 // the rest with [DefaultMaskChar]. See [KeepFirstN].
 //

--- a/rules_telecom.go
+++ b/rules_telecom.go
@@ -1,0 +1,543 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"strings"
+)
+
+// Telecom-category rules implement the 9 masks from
+// docs/v0.9.0-requirements.md §"Telecommunications and Location".
+// Identifier rules (phone, mobile_phone_number, imei, imsi, msisdn)
+// preserve a deterministic prefix (country code or fixed index)
+// plus the last 2-4 digits; location rules reduce numeric precision
+// or dispatch on postal-code shape. Every rule is fail-closed:
+// malformed input routes to [SameLengthMask].
+
+// ---------- file-local constants ----------
+
+// imeiLen is the canonical IMEI length (14 digits + Luhn check
+// digit). The rule does not verify the Luhn digit — masking is not
+// validation — but any length other than 15 fails closed.
+const imeiLen = 15
+
+// imsiLen is the canonical IMSI length (3-digit MCC + 2-3 digit MNC
+// + subscriber ID). We accept exactly 15 ASCII digits; 14-digit
+// variants fail closed to keep the rule unambiguous.
+const imsiLen = 15
+
+// imsiKeepFirst / imsiKeepLast are the preserved window counts per
+// the spec example (first 5 MCC+MNC digits + last 4 subscriber).
+const (
+	imsiKeepFirst = 5
+	imsiKeepLast  = 4
+)
+
+// msisdnKeepFirst / msisdnKeepLast are the preserved window counts
+// on MSISDN. The spec example uses a 2-digit country code (UK 44);
+// country codes can be 1-3 digits but a strict lookup table is out
+// of scope for v0.9.0. Operators needing strict per-country
+// handling should route such fields through `phone_number` in
+// E.164 form instead.
+const (
+	msisdnKeepFirst = 2
+	msisdnKeepLast  = 4
+	msisdnMinLen    = 10
+	msisdnMaxLen    = 15
+)
+
+// msisdnLen ranges are inclusive. Shorter inputs fail closed.
+
+// phoneKeepLast is the trailing digit window preserved by
+// `phone_number` after the country-code literal.
+const phoneKeepLast = 4
+
+// ccMaxDigits is the cap on country-code length when parsing the
+// leading `+NN` prefix of a phone number. ITU-T E.164 assigns up
+// to 3-digit country codes, so 3 is the strict cap.
+const ccMaxDigits = 3
+
+// imeiKeepLast is the trailing digit window preserved by `imei`.
+const imeiKeepLast = 4
+
+// geoDecimals is the default decimal-place precision for
+// `geo_latitude` and `geo_longitude`. Two decimals resolve to
+// approximately 1.1 km at the equator — sufficient for "city
+// district" granularity without identifying a street address.
+const geoDecimals = 2
+
+// ---------- rune / byte classifiers ----------
+
+// isTelecomSeparator reports whether r is a character we admit as
+// a phone-number structural separator. ASCII only — non-ASCII
+// bytes in a phone number field fail closed elsewhere.
+func isTelecomSeparator(r rune) bool {
+	switch r {
+	case ' ', '-', '.', '(', ')', '/':
+		return true
+	}
+	return false
+}
+
+// ---------- phone_number / mobile_phone_number ----------
+
+// maskPhoneNumber preserves a leading `+NN` country code literal
+// and the last 4 digits, masking every other digit while keeping
+// structural separators verbatim. Inputs without a `+` prefix
+// route through the same helper with an empty prefix — the whole
+// input is treated as the body. Inputs whose body contains fewer
+// than 4 digits fail closed over the whole value (the prefix is
+// NOT echoed on short bodies).
+//
+// Spec examples:
+//
+//	+44 7911 123456   → +44 **** **3456
+//	(555) 123-4567    → (***) ***-4567
+//	+1-800-555-0199   → +1-***-***-0199
+//
+// The rule accepts `mobile_phone_number` as an alias — the spec
+// notes "prefer one international abstraction unless business rules
+// differ". Operators needing jurisdiction-specific mobile rules
+// should register a custom rule under the original name on a
+// dedicated Masker.
+func maskPhoneNumber(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	prefix, body, ok := splitPhonePrefix(v)
+	if !ok {
+		return SameLengthMask(v, c)
+	}
+	if !isTelecomBody(body) {
+		return SameLengthMask(v, c)
+	}
+	bodyDigits := countPhoneDigits(body)
+	return keepFirstLastNonSepWithPrefix(prefix, body, 0, phoneKeepLast, bodyDigits, c, isTelecomSeparator)
+}
+
+// splitPhonePrefix returns ("+NN", rest, true) when v starts with a
+// `+` followed by 1-3 ASCII digits terminated by a separator.
+// Otherwise returns ("", v, true) — the whole value is the body.
+// Returns (_, _, false) only when the leading `+` is malformed
+// (zero or >3 digits before separator / end of string).
+func splitPhonePrefix(v string) (string, string, bool) {
+	if v[0] != '+' {
+		return "", v, true
+	}
+	i := 1
+	for i < len(v) && i-1 < ccMaxDigits && isASCIIDecDigit(v[i]) {
+		i++
+	}
+	digits := i - 1
+	if digits == 0 {
+		return "", "", false
+	}
+	if i == len(v) {
+		// `+44` with no body — body is empty, no separator required.
+		return v, "", true
+	}
+	if !isTelecomSeparator(rune(v[i])) {
+		return "", "", false
+	}
+	// Prefix includes the terminating separator so the body walk
+	// starts on the first body digit/separator.
+	return v[:i+1], v[i+1:], true
+}
+
+// isTelecomBody reports whether body consists only of ASCII digits
+// and telecom separators. The last rune must NOT be a separator —
+// trailing spaces / hyphens / dots would otherwise echo unmasked.
+// The first rune is allowed to be `(` (US-format wrap character,
+// matches the spec example `(555) 123-4567`); any other leading
+// separator fails closed.
+func isTelecomBody(body string) bool {
+	if body == "" {
+		return true
+	}
+	first := body[0]
+	if isTelecomSeparator(rune(first)) && first != '(' {
+		return false
+	}
+	if isTelecomSeparator(rune(body[len(body)-1])) {
+		return false
+	}
+	for i := 0; i < len(body); i++ {
+		b := body[i]
+		if isASCIIDecDigit(b) {
+			continue
+		}
+		if !isTelecomSeparator(rune(b)) {
+			return false
+		}
+	}
+	return true
+}
+
+// countPhoneDigits counts ASCII decimal digits in body. Body is
+// guaranteed ASCII-only by [isTelecomBody].
+func countPhoneDigits(body string) int {
+	n := 0
+	for i := 0; i < len(body); i++ {
+		if isASCIIDecDigit(body[i]) {
+			n++
+		}
+	}
+	return n
+}
+
+// ---------- imei ----------
+
+// maskIMEI preserves the last 4 digits of a 15-digit IMEI. Any
+// length other than 15 or any non-digit byte fails closed.
+func maskIMEI(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if len(v) != imeiLen || !allASCIIDigits(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepLastN(v, imeiKeepLast, c)
+}
+
+// allASCIIDigits reports whether s is non-empty and every byte is an
+// ASCII decimal digit.
+func allASCIIDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isASCIIDecDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------- imsi ----------
+
+// maskIMSI preserves the first 5 and last 4 digits of a 15-digit
+// IMSI. Any length other than 15 or any non-digit byte fails closed.
+func maskIMSI(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if len(v) != imsiLen || !allASCIIDigits(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, imsiKeepFirst, imsiKeepLast, c)
+}
+
+// ---------- msisdn ----------
+
+// maskMSISDN preserves the first 2 and last 4 digits of a 10-15
+// digit MSISDN. Any length outside that range, any non-digit byte,
+// or a leading `+` (which would be E.164 territory — use
+// `phone_number` instead) fails closed.
+func maskMSISDN(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if len(v) < msisdnMinLen || len(v) > msisdnMaxLen || !allASCIIDigits(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, msisdnKeepFirst, msisdnKeepLast, c)
+}
+
+// ---------- postal_code ----------
+
+// maskPostalCode is a shape-dispatching rule. UK, US, and Canadian
+// forms are recognised; any other shape fails closed. Uppercase
+// ASCII required on alphabetic codes — lowercase variants fail
+// closed.
+//
+// Spec examples:
+//
+//	SW1A 2AA  →  SW1A ***  (UK — keep outward code)
+//	94103     →  941**     (US — keep first 3)
+//	M5V 2T6   →  M5V ***   (Canada — keep FSA)
+func maskPostalCode(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if out, ok := maskUKPostalCode(v, c); ok {
+		return out
+	}
+	if out, ok := maskCAPostalCode(v, c); ok {
+		return out
+	}
+	if out, ok := maskUSPostalCode(v, c); ok {
+		return out
+	}
+	return SameLengthMask(v, c)
+}
+
+// maskUKPostalCode accepts 6-8 byte UK codes: outward code of 2-4
+// ASCII characters (first byte letter, remainder letter/digit),
+// single ASCII space, then `d[A-Z]{2}` inward code. Output
+// preserves the outward code + space and masks the inward code.
+func maskUKPostalCode(v string, c rune) (string, bool) {
+	n := len(v)
+	if n < 6 || n > 8 {
+		return "", false
+	}
+	if v[n-4] != ' ' {
+		return "", false
+	}
+	outward := v[:n-4]
+	inward := v[n-3:]
+	if !isUKOutwardCode(outward) || !isUKInwardCode(inward) {
+		return "", false
+	}
+	var b strings.Builder
+	b.Grow(len(outward) + 1 + 3*safeRuneLen(c))
+	b.WriteString(outward)
+	b.WriteByte(' ')
+	writeMaskRunes(&b, c, 3)
+	return b.String(), true
+}
+
+// isUKOutwardCode reports whether s is a valid outward-code shape:
+// first byte is A-Z; remaining 1-3 bytes are A-Z or 0-9 with at
+// least one digit somewhere (outward codes always contain a
+// district digit).
+func isUKOutwardCode(s string) bool {
+	if len(s) < 2 || len(s) > 4 {
+		return false
+	}
+	if !isASCIIUpperLetter(s[0]) {
+		return false
+	}
+	sawDigit := false
+	for i := 1; i < len(s); i++ {
+		b := s[i]
+		switch {
+		case isASCIIUpperLetter(b):
+		case isASCIIDecDigit(b):
+			sawDigit = true
+		default:
+			return false
+		}
+	}
+	return sawDigit
+}
+
+// isUKInwardCode reports whether s is `d[A-Z]{2}`.
+func isUKInwardCode(s string) bool {
+	if len(s) != 3 {
+		return false
+	}
+	return isASCIIDecDigit(s[0]) && isASCIIUpperLetter(s[1]) && isASCIIUpperLetter(s[2])
+}
+
+// maskCAPostalCode accepts `L#L #L#` (7 bytes): letter-digit-letter
+// space digit-letter-digit. Output preserves the FSA (first 3
+// bytes) + space and masks the LDU.
+func maskCAPostalCode(v string, c rune) (string, bool) {
+	if len(v) != 7 || v[3] != ' ' {
+		return "", false
+	}
+	if !isASCIIUpperLetter(v[0]) || !isASCIIDecDigit(v[1]) || !isASCIIUpperLetter(v[2]) {
+		return "", false
+	}
+	if !isASCIIDecDigit(v[4]) || !isASCIIUpperLetter(v[5]) || !isASCIIDecDigit(v[6]) {
+		return "", false
+	}
+	var b strings.Builder
+	b.Grow(4 + 3*safeRuneLen(c))
+	b.WriteString(v[:4])
+	writeMaskRunes(&b, c, 3)
+	return b.String(), true
+}
+
+// maskUSPostalCode accepts exactly 5 ASCII digits (basic ZIP).
+// ZIP+4 forms (`94103-6789`) are not currently recognised — they
+// fail closed and can be added in a follow-up.
+func maskUSPostalCode(v string, c rune) (string, bool) {
+	if len(v) != 5 || !allASCIIDigits(v) {
+		return "", false
+	}
+	// US ZIP codes are always exactly 5 ASCII digits, so we can use a
+	// direct builder instead of KeepFirstN (which calls
+	// utf8.RuneCountInString + byteOffsetAtRune over the whole string).
+	// This matches the inline pattern used by maskCAPostalCode and
+	// maskUKPostalCode and avoids the two extra O(n) scans.
+	var b strings.Builder
+	b.Grow(3 + 2*safeRuneLen(c))
+	b.WriteString(v[:3])
+	writeMaskRunes(&b, c, 2)
+	return b.String(), true
+}
+
+// isASCIIUpperLetter reports whether b is A-Z.
+func isASCIIUpperLetter(b byte) bool { return b >= 'A' && b <= 'Z' }
+
+// ---------- geo_latitude / geo_longitude ----------
+
+// maskGeoNumber applies [ReducePrecision] to v but fails closed
+// when v has no fractional part or fewer digits after the decimal
+// point than the masking would consume — those cases would make
+// `ReducePrecision` echo the input verbatim.
+func maskGeoNumber(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	dot := strings.IndexByte(v, '.')
+	if dot < 0 {
+		return SameLengthMask(v, c)
+	}
+	if dot+1+geoDecimals >= len(v) {
+		return SameLengthMask(v, c)
+	}
+	return ReducePrecision(v, geoDecimals, c)
+}
+
+// ---------- geo_coordinates ----------
+
+// maskGeoCoordinates splits v on a single ASCII comma and applies
+// [maskGeoNumber] to each half. Fails closed on zero or multiple
+// commas, on whitespace around the comma, or on either half failing
+// the plain-decimal-with-fractional-part check.
+func maskGeoCoordinates(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	comma := strings.IndexByte(v, ',')
+	if comma <= 0 || comma == len(v)-1 {
+		return SameLengthMask(v, c)
+	}
+	if strings.IndexByte(v[comma+1:], ',') >= 0 {
+		return SameLengthMask(v, c)
+	}
+	lat := v[:comma]
+	lon := v[comma+1:]
+	if !isGeoMaskable(lat) || !isGeoMaskable(lon) {
+		return SameLengthMask(v, c)
+	}
+	// Build the result in a single allocation. The output for each half
+	// has the same length as the input when c is a single-byte rune; the
+	// tail digits may expand by (cLen-1) bytes each when c is multi-byte.
+	// Worst case: each byte in each half is masked → len*cLen bytes.
+	cLen := safeRuneLen(c)
+	var b strings.Builder
+	b.Grow(len(lat)*cLen + 1 + len(lon)*cLen)
+	writeReducePrecision(&b, lat, geoDecimals, c)
+	b.WriteByte(',')
+	writeReducePrecision(&b, lon, geoDecimals, c)
+	return b.String()
+}
+
+// isGeoMaskable reports whether s has the shape [maskGeoNumber]
+// would successfully mask — a plain decimal with a fractional
+// portion long enough for at least one digit to be masked past the
+// configured precision. Short-circuits the `maskGeoNumber`
+// fail-closed path so [maskGeoCoordinates] can decide to fail
+// closed on the WHOLE pair rather than produce half-masked output.
+// Also rejects inputs with multiple `.` bytes; `ReducePrecision`
+// would otherwise correctly fall back for the multi-dot half, but
+// [maskGeoCoordinates] joins the halves directly so a per-half
+// fallback would leak the other half of the pair.
+func isGeoMaskable(s string) bool {
+	if s == "" || s[0] == '+' {
+		return false
+	}
+	dot := strings.IndexByte(s, '.')
+	if dot < 0 ||
+		strings.IndexByte(s[dot+1:], '.') >= 0 ||
+		dot+1+geoDecimals >= len(s) {
+		return false
+	}
+	return hasOnlyDecimalBytes(s)
+}
+
+// hasOnlyDecimalBytes reports whether s is composed solely of ASCII
+// decimal digits, a single leading `-`, and (possibly) `.` bytes.
+// The leading-sign and `.` placement are validated by the caller —
+// this helper only gates the character class.
+func hasOnlyDecimalBytes(s string) bool {
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		switch {
+		case i == 0 && b == '-':
+		case b == '.':
+		case isASCIIDecDigit(b):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ---------- registration ----------
+
+// registerTelecomRules wires every rule in this file against m.
+func registerTelecomRules(m *Masker) {
+	phone := func(v string) string { return maskPhoneNumber(v, m.maskChar()) }
+	m.mustRegisterBuiltin("phone_number", phone,
+		RuleInfo{
+			Name: "phone_number", Category: "telecom", Jurisdiction: "global",
+			Description: "Preserves a leading +NN country code (if present) and the last 4 digits; masks middle digits while preserving structural separators. Example: +44 7911 123456 → +44 **** **3456.",
+		})
+	m.mustRegisterBuiltin("mobile_phone_number", phone,
+		RuleInfo{
+			Name: "mobile_phone_number", Category: "telecom", Jurisdiction: "global",
+			Description: "Alias of `phone_number`; preserves +NN country code and last 4 digits, masks the middle. The spec notes mobile-specific jurisdictions may diverge; operators needing that should register a custom rule. Example: +44 7911 123456 → +44 **** **3456.",
+		})
+	m.mustRegisterBuiltin("imei",
+		func(v string) string { return maskIMEI(v, m.maskChar()) },
+		RuleInfo{
+			Name: "imei", Category: "telecom", Jurisdiction: "global",
+			Description: "Preserves the last 4 digits of a 15-digit IMEI; all other inputs fail closed. Example: 353456789012345 → ***********2345.",
+		})
+	m.mustRegisterBuiltin("imsi",
+		func(v string) string { return maskIMSI(v, m.maskChar()) },
+		RuleInfo{
+			Name: "imsi", Category: "telecom", Jurisdiction: "global",
+			Description: "Preserves the first 5 (MCC+MNC) and last 4 digits of a 15-digit IMSI; other inputs fail closed. Example: 310260123456789 → 31026******6789.",
+		})
+	m.mustRegisterBuiltin("msisdn",
+		func(v string) string { return maskMSISDN(v, m.maskChar()) },
+		RuleInfo{
+			Name: "msisdn", Category: "telecom", Jurisdiction: "global",
+			Description: "Preserves the first 2 and last 4 digits of a 10-15 digit MSISDN; inputs with a leading `+` fail closed — use `phone_number` for E.164 input. Example: 447911123456 → 44******3456.",
+		})
+	m.mustRegisterBuiltin("postal_code",
+		func(v string) string { return maskPostalCode(v, m.maskChar()) },
+		RuleInfo{
+			Name: "postal_code", Category: "location", Jurisdiction: "global (country-aware precision reduction)",
+			Description: "Shape-aware across UK (keep outward code), US 5-digit ZIP (keep first 3), and Canada (keep FSA); other shapes fail closed. Example: SW1A 2AA → SW1A ***.",
+		})
+	m.mustRegisterBuiltin("geo_latitude",
+		func(v string) string { return maskGeoNumber(v, m.maskChar()) },
+		RuleInfo{
+			Name: "geo_latitude", Category: "location", Jurisdiction: "global",
+			Description: "Reduces decimal precision to 2 places by truncation (not rounding); input without a fractional part fails closed. Roughly 1.1 km resolution — not anonymisation. Example: 37.7749295 → 37.77*****.",
+		})
+	m.mustRegisterBuiltin("geo_longitude",
+		func(v string) string { return maskGeoNumber(v, m.maskChar()) },
+		RuleInfo{
+			Name: "geo_longitude", Category: "location", Jurisdiction: "global",
+			Description: "Reduces decimal precision to 2 places by truncation (not rounding); input without a fractional part fails closed. Example: -122.4194155 → -122.42*****.",
+		})
+	m.mustRegisterBuiltin("geo_coordinates",
+		func(v string) string { return maskGeoCoordinates(v, m.maskChar()) },
+		RuleInfo{
+			Name: "geo_coordinates", Category: "location", Jurisdiction: "global",
+			Description: "Splits on a single comma and applies `geo_latitude` / `geo_longitude` to each half; any other shape fails closed. Example: 37.7749,-122.4194 → 37.77**,-122.42**.",
+		})
+}
+
+func init() {
+	builtinRegistrars = append(builtinRegistrars, registerTelecomRules)
+}

--- a/rules_telecom_bench_test.go
+++ b/rules_telecom_bench_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import "testing"
+
+// runBench is defined in rules_technology_bench_test.go and reused
+// across phases to keep benchmark boilerplate uniform.
+
+// ---------- phone_number / mobile_phone_number ----------
+
+func BenchmarkApply_phone_number_e164(b *testing.B) {
+	runBench(b, "phone_number", "+44 7911 123456")
+}
+func BenchmarkApply_phone_number_us_local(b *testing.B) {
+	runBench(b, "phone_number", "(555) 123-4567")
+}
+func BenchmarkApply_phone_number_invalid(b *testing.B) {
+	runBench(b, "phone_number", "1-800-FLOWERS")
+}
+func BenchmarkApply_phone_number_long(b *testing.B) {
+	// 30-digit body: exercises the O(n) isTelecomBody + countPhoneDigits loops.
+	runBench(b, "phone_number", "+44 7911 123456 789012 345678 901234")
+}
+func BenchmarkApply_mobile_phone_number(b *testing.B) {
+	runBench(b, "mobile_phone_number", "+44 7911 123456")
+}
+
+// ---------- imei / imsi / msisdn ----------
+
+func BenchmarkApply_imei(b *testing.B)         { runBench(b, "imei", "353456789012345") }
+func BenchmarkApply_imei_invalid(b *testing.B) { runBench(b, "imei", "35-345678-901234-5") }
+func BenchmarkApply_imsi(b *testing.B)         { runBench(b, "imsi", "310260123456789") }
+func BenchmarkApply_imsi_invalid(b *testing.B) { runBench(b, "imsi", "310-260-123456789") }
+func BenchmarkApply_msisdn(b *testing.B)       { runBench(b, "msisdn", "447911123456") }
+func BenchmarkApply_msisdn_invalid(b *testing.B) {
+	runBench(b, "msisdn", "+447911123456")
+}
+
+// ---------- postal_code ----------
+
+func BenchmarkApply_postal_code_uk(b *testing.B) { runBench(b, "postal_code", "SW1A 2AA") }
+func BenchmarkApply_postal_code_us(b *testing.B) { runBench(b, "postal_code", "94103") }
+func BenchmarkApply_postal_code_ca(b *testing.B) { runBench(b, "postal_code", "M5V 2T6") }
+func BenchmarkApply_postal_code_unknown(b *testing.B) {
+	runBench(b, "postal_code", "01310-100")
+}
+
+// ---------- geo_latitude / geo_longitude / geo_coordinates ----------
+
+func BenchmarkApply_geo_latitude(b *testing.B) { runBench(b, "geo_latitude", "37.7749295") }
+func BenchmarkApply_geo_latitude_invalid(b *testing.B) {
+	// Integer input has no fractional part; routes to SameLengthMask.
+	runBench(b, "geo_latitude", "37")
+}
+func BenchmarkApply_geo_longitude(b *testing.B) { runBench(b, "geo_longitude", "-122.4194155") }
+func BenchmarkApply_geo_longitude_invalid(b *testing.B) {
+	// Integer input has no fractional part; routes to SameLengthMask.
+	runBench(b, "geo_longitude", "-122")
+}
+func BenchmarkApply_geo_coordinates(b *testing.B) {
+	runBench(b, "geo_coordinates", "37.7749,-122.4194")
+}
+func BenchmarkApply_geo_coordinates_invalid(b *testing.B) {
+	runBench(b, "geo_coordinates", "nothing,at all")
+}

--- a/rules_telecom_test.go
+++ b/rules_telecom_test.go
@@ -1,0 +1,373 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/mask"
+)
+
+// ---------- phone_number ----------
+
+func TestApply_PhoneNumber(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec e164 uk", "+44 7911 123456", "+44 **** **3456"},
+		{"spec parens us", "(555) 123-4567", "(***) ***-4567"},
+		{"spec e164 us", "+1-800-555-0199", "+1-***-***-0199"},
+		{"empty", "", ""},
+		{"plus alone fails closed", "+", "*"},
+		{"plus then separator fails closed", "+ 7911", "******"},
+		{"body with fewer than four digits fails closed", "+44 12", "******"},
+		{"body exactly four digits keeps whole tail", "+44 1234", "********"},
+		{"body five digits keeps last four", "+44 12345", "+44 *2345"},
+		{"letters fail closed", "1-800-FLOWERS", "*************"},
+		{"arabic-indic digits fail closed", "٠٧٩١١ ١٢٣٤٥٦", "************"},
+		{"nbsp separator fails closed", "+44\u00a07911 123456", "***************"},
+		{"nul byte fails closed", "+44 7911\x00123456", "***************"},
+		{"four digit country code fails closed", "+1234 567 8901", "**************"},
+		{"trailing space fails closed", "+44 7911 123456 ", "****************"},
+		{"trailing hyphen fails closed", "(555) 123-4567-", "***************"},
+		{"leading hyphen fails closed", "-(555) 123-4567", "***************"},
+		{"bare country code fails closed", "+44", "***"},
+		{"double plus fails closed", "++44 7911", "*********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("phone_number", tc.in))
+		})
+	}
+}
+
+func TestApply_MobilePhoneNumber_Alias(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	// mobile_phone_number is an alias for phone_number — identical
+	// output for every input, per the spec's "prefer one
+	// international abstraction" guidance.
+	cases := []string{
+		"+44 7911 123456",
+		"(555) 123-4567",
+		"07911 123456",
+		"",
+		"nonsense",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, m.Apply("phone_number", in), m.Apply("mobile_phone_number", in))
+		})
+	}
+}
+
+// ---------- imei ----------
+
+func TestApply_IMEI(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "353456789012345", "***********2345"},
+		{"empty", "", ""},
+		{"fourteen digits fails closed", "35345678901234", "**************"},
+		{"sixteen digits fails closed", "3534567890123456", "****************"},
+		{"letter O masquerading as zero fails closed", "353456789O12345", "***************"},
+		{"with separators fails closed", "35-345678-901234-5", "******************"},
+		{"all zeros", "000000000000000", "***********0000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("imei", tc.in))
+		})
+	}
+}
+
+// ---------- imsi ----------
+
+func TestApply_IMSI(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "310260123456789", "31026******6789"},
+		{"empty", "", ""},
+		{"fourteen digits fails closed", "31026012345678", "**************"},
+		{"sixteen digits fails closed", "3102601234567890", "****************"},
+		{"with separators fails closed", "310-260-123456789", "*****************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("imsi", tc.in))
+		})
+	}
+}
+
+// ---------- msisdn ----------
+
+func TestApply_MSISDN(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "447911123456", "44******3456"},
+		{"empty", "", ""},
+		{"minimum length ten", "4479111234", "44****1234"},
+		{"maximum length fifteen", "447911123456789", "44*********6789"},
+		{"nine digits fails closed", "479111234", "*********"},
+		{"sixteen digits fails closed", "4479111234567891", "****************"},
+		{"leading plus fails closed", "+447911123456", "*************"},
+		{"letters fail closed", "447911abc456", "************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("msisdn", tc.in))
+		})
+	}
+}
+
+// ---------- postal_code ----------
+
+func TestApply_PostalCode(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec uk 8-byte", "SW1A 2AA", "SW1A ***"},
+		{"spec us", "94103", "941**"},
+		{"spec canada", "M5V 2T6", "M5V ***"},
+		{"empty", "", ""},
+		{"uk short 6-byte", "M1 1AA", "M1 ***"},
+		{"uk mid 7-byte", "M25 5AA", "M25 ***"},
+		{"uk lowercase fails closed", "sw1a 2aa", "********"},
+		{"uk missing space fails closed", "SW1A2AA", "*******"},
+		{"us zip plus four fails closed", "94103-6789", "**********"},
+		{"ca lowercase fails closed", "m5v 2t6", "*******"},
+		{"ca missing space fails closed", "M5V2T6", "******"},
+		{"de 5-digit masks as us shape", "10115", "101**"},
+		{"random short fails closed", "AB123", "*****"},
+		{"already masked uk fails closed", "SW1A ***", "********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("postal_code", tc.in))
+		})
+	}
+}
+
+// ---------- geo_latitude ----------
+
+func TestApply_GeoLatitude(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "37.7749295", "37.77*****"},
+		// Truncation, not rounding: ReducePrecision operates
+		// byte-by-byte and preserves `-33.86`. The spec's
+		// `-33.87***` example is a typo.
+		{"spec negative truncates not rounds", "-33.8688197", "-33.86*****"},
+		{"empty", "", ""},
+		{"integer fails closed", "42", "**"},
+		{"integer with sign fails closed", "-42", "***"},
+		{"too few decimals fails closed", "37.7", "****"},
+		{"exactly two decimals fails closed (nothing to mask)", "37.77", "*****"},
+		{"scientific fails closed", "3.77e1", "******"},
+		{"multiple dots fails closed", "37.77.49", "********"},
+		{"leading plus fails closed", "+37.77", "******"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("geo_latitude", tc.in))
+		})
+	}
+}
+
+// ---------- geo_longitude ----------
+
+func TestApply_GeoLongitude(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "-122.4194155", "-122.41*****"},
+		{"empty", "", ""},
+		{"positive", "139.6503", "139.65**"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("geo_longitude", tc.in))
+		})
+	}
+}
+
+// ---------- geo_coordinates ----------
+
+func TestApply_GeoCoordinates(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "37.7749,-122.4194", "37.77**,-122.41**"},
+		{"empty", "", ""},
+		{"no comma fails closed", "37.7749", "*******"},
+		{"two commas fails closed", "1,2,3", "*****"},
+		{"space after comma fails closed", "37.77, -122.42", "**************"},
+		{"partial malformed fails closed", "37.77,abc", "*********"},
+		{"parens fails closed", "(37.77,-122.42)", "***************"},
+		{"leading comma fails closed", ",37.77", "******"},
+		{"trailing comma fails closed", "37.77,", "******"},
+		{"multi-dot half leaks nothing", "37.77.49,-122.4194", "******************"},
+		{"multi-dot second half leaks nothing", "37.7749,-122.42..", "*****************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("geo_coordinates", tc.in))
+		})
+	}
+}
+
+// ---------- mask-character override ----------
+
+func TestTelecom_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	cases := []struct{ rule, in, want string }{
+		{"phone_number", "+44 7911 123456", "+44 XXXX XX3456"},
+		{"mobile_phone_number", "+44 7911 123456", "+44 XXXX XX3456"},
+		{"imei", "353456789012345", "XXXXXXXXXXX2345"},
+		{"imsi", "310260123456789", "31026XXXXXX6789"},
+		{"msisdn", "447911123456", "44XXXXXX3456"},
+		{"postal_code", "SW1A 2AA", "SW1A XXX"},
+		{"geo_latitude", "37.7749295", "37.77XXXXX"},
+		{"geo_longitude", "-122.4194155", "-122.41XXXXX"},
+		{"geo_coordinates", "37.7749,-122.4194", "37.77XX,-122.41XX"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply(tc.rule, tc.in))
+		})
+	}
+}
+
+// ---------- registrations and metadata ----------
+
+func TestDescribe_TelecomRules(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	telecomNames := []string{"phone_number", "mobile_phone_number", "imei", "imsi", "msisdn"}
+	locationNames := []string{"postal_code", "geo_latitude", "geo_longitude", "geo_coordinates"}
+	for _, n := range telecomNames {
+		t.Run(n, func(t *testing.T) {
+			info, ok := m.Describe(n)
+			require.True(t, ok, "rule %q not registered", n)
+			assert.Equal(t, "telecom", info.Category)
+			assert.NotEmpty(t, info.Jurisdiction)
+			assert.Contains(t, info.Description, "Example:", "rule %q description must include an Example", n)
+			assert.Equal(t, n, info.Name)
+		})
+	}
+	for _, n := range locationNames {
+		t.Run(n, func(t *testing.T) {
+			info, ok := m.Describe(n)
+			require.True(t, ok, "rule %q not registered", n)
+			assert.Equal(t, "location", info.Category)
+			assert.NotEmpty(t, info.Jurisdiction)
+			assert.Contains(t, info.Description, "Example:", "rule %q description must include an Example", n)
+			assert.Equal(t, n, info.Name)
+		})
+	}
+}
+
+// TestTelecom_FailClosedOnMalformed confirms every rule either
+// same-length-masks the input or registers as identical output
+// shape — never echoes a malformed input verbatim.
+func TestTelecom_FailClosedOnMalformed(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	malformed := "completely-not-a-telecom-value-xx"
+	names := []string{
+		"phone_number", "mobile_phone_number", "imei", "imsi",
+		"msisdn", "postal_code", "geo_latitude", "geo_longitude",
+		"geo_coordinates",
+	}
+	for _, n := range names {
+		t.Run(n, func(t *testing.T) {
+			got := m.Apply(n, malformed)
+			assert.NotEqual(t, malformed, got, "rule %q echoed malformed input", n)
+			assert.Equal(t, strings.Repeat("*", utf8.RuneCountInString(malformed)), got,
+				"rule %q did not produce same-length mask on malformed input", n)
+		})
+	}
+}
+
+// TestTelecom_NoPanicOnAdversarialInput mirrors the phase 4d / 4c
+// contract — every rule must handle adversarial bytes without
+// panicking and emit well-formed UTF-8.
+func TestTelecom_NoPanicOnAdversarialInput(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	adversarial := []string{
+		"",
+		"\xff\xfe\xfd",
+		"\x00",
+		strings.Repeat("9", 1000),
+		"\u200B+44 7911 123456",
+		"37.77\u202E49,-122.42",
+		"+44\x00 7911 123456",
+		"SW1A\u00A02AA",
+	}
+	names := []string{
+		"phone_number", "mobile_phone_number", "imei", "imsi",
+		"msisdn", "postal_code", "geo_latitude", "geo_longitude",
+		"geo_coordinates",
+	}
+	for _, n := range names {
+		for _, in := range adversarial {
+			var got string
+			assert.NotPanics(t, func() { got = m.Apply(n, in) },
+				"rule %q panicked on input %q", n, in)
+			assert.True(t, utf8.ValidString(got),
+				"rule %q produced invalid UTF-8 for input %q: %q", n, in, got)
+		}
+	}
+}
+
+// TestTelecom_IdempotencyMatrix pins the 2nd-pass behaviour of each
+// rule. All 9 rules produce masked output that is NOT parseable by
+// the same rule on a second application — mask runes aren't valid
+// digits / hex / letters in any of the rule grammars — so every
+// rule is non-idempotent by design.
+func TestTelecom_IdempotencyMatrix(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in string }{
+		{"phone_number", "+44 7911 123456"},
+		{"mobile_phone_number", "+44 7911 123456"},
+		{"imei", "353456789012345"},
+		{"imsi", "310260123456789"},
+		{"msisdn", "447911123456"},
+		{"postal_code", "SW1A 2AA"},
+		{"geo_latitude", "37.7749295"},
+		{"geo_longitude", "-122.4194155"},
+		{"geo_coordinates", "37.7749,-122.4194"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first := m.Apply(tc.name, tc.in)
+			second := m.Apply(tc.name, first)
+			assert.NotEqual(t, first, second,
+				"rule %q was expected to be non-idempotent (output collapses to same-length mask)", tc.name)
+		})
+	}
+}

--- a/tests/bdd/features/telecom.feature
+++ b/tests/bdd/features/telecom.feature
@@ -1,0 +1,144 @@
+@telecom
+Feature: Telecom and location masking rules
+  The telecom category covers the 9 rules from
+  docs/v0.9.0-requirements.md §"Telecommunications and Location":
+  phone_number, mobile_phone_number (alias of phone_number),
+  imei, imsi, msisdn, postal_code, geo_latitude, geo_longitude,
+  geo_coordinates. Every rule is fail-closed — malformed input
+  routes to a same-length mask rather than being echoed.
+
+  Scenario Outline: Mask phone numbers
+    Given a fresh masker
+    When I apply "phone_number" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input            | expected         |
+      | +44 7911 123456  | +44 **** **3456  |
+      | (555) 123-4567   | (***) ***-4567   |
+      | +1-800-555-0199  | +1-***-***-0199  |
+      | 1-800-FLOWERS    | *************    |
+      |                  |                  |
+
+  Scenario: phone_number honours per-instance mask character
+    Given a fresh masker with mask character "X"
+    When I apply "phone_number" to "+44 7911 123456"
+    Then the result is "+44 XXXX XX3456"
+
+  Scenario Outline: mobile_phone_number is an alias of phone_number
+    Given a fresh masker
+    When I apply "mobile_phone_number" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input            | expected         |
+      | +44 7911 123456  | +44 **** **3456  |
+      | 07911 123456     | ***** **3456     |
+
+  Scenario Outline: Mask IMEIs
+    Given a fresh masker
+    When I apply "imei" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | expected           |
+      | 353456789012345    | ***********2345    |
+      | 35345678901234     | **************     |
+      | 3534567890123456   | ****************   |
+      |                    |                    |
+
+  Scenario Outline: Mask IMSIs
+    Given a fresh masker
+    When I apply "imsi" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | expected           |
+      | 310260123456789    | 31026******6789    |
+      | 31026012345678     | **************     |
+      |                    |                    |
+
+  Scenario Outline: Mask MSISDNs
+    Given a fresh masker
+    When I apply "msisdn" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input             | expected          |
+      | 447911123456      | 44******3456      |
+      | 4479111234        | 44****1234        |
+      | +447911123456     | *************     |
+      |                   |                   |
+
+  Scenario Outline: Mask postal codes
+    # Shape-aware dispatch: UK, US, and Canada. Other shapes fail
+    # closed. Lowercase variants fail closed to keep output
+    # unambiguous.
+    Given a fresh masker
+    When I apply "postal_code" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input      | expected   |
+      | SW1A 2AA   | SW1A ***   |
+      | M1 1AA     | M1 ***     |
+      | 94103      | 941**      |
+      | M5V 2T6    | M5V ***    |
+      | sw1a 2aa   | ********   |
+      | 94103-6789 | **********  |
+      | 01310-100  | *********  |
+      |            |            |
+
+  Scenario Outline: Mask geo latitudes
+    Given a fresh masker
+    When I apply "geo_latitude" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input        | expected      |
+      | 37.7749295   | 37.77*****    |
+      | -33.8688197  | -33.86*****   |
+      | 42           | **            |
+      | 3.77e1       | ******        |
+      |              |               |
+
+  Scenario Outline: Mask geo longitudes
+    Given a fresh masker
+    When I apply "geo_longitude" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input         | expected       |
+      | -122.4194155  | -122.41*****   |
+      | 139.6503      | 139.65**       |
+      |               |                |
+
+  Scenario Outline: Mask geo coordinate pairs
+    Given a fresh masker
+    When I apply "geo_coordinates" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | expected           |
+      | 37.7749,-122.4194  | 37.77**,-122.41**  |
+      | 37.7749            | *******            |
+      | 37.77,abc          | *********          |
+      | 37.77, -122.42     | **************     |
+      |                    |                    |
+
+  Scenario Outline: Every telecom rule handles empty input consistently
+    Given a fresh masker
+    When I apply "<rule>" to ""
+    Then the result is "<expected>"
+
+    Examples:
+      | rule                | expected |
+      | phone_number        |          |
+      | mobile_phone_number |          |
+      | imei                |          |
+      | imsi                |          |
+      | msisdn              |          |
+      | postal_code         |          |
+      | geo_latitude        |          |
+      | geo_longitude       |          |
+      | geo_coordinates     |          |


### PR DESCRIPTION
## Summary

Implements the 9 telecom/location rules from `docs/v0.9.0-requirements.md` §"Telecommunications and Location".

- **phone_number / mobile_phone_number** — preserves leading `+NN` country code and last 4 digits; mobile aliased per spec note. Trailing separators fail closed; leading `(` allowed (US parens format).
- **imei / imsi / msisdn** — fixed-length digit validators with preserved-window rules.
- **postal_code** — shape-dispatch across UK, US 5-digit ZIP, and Canada. Lowercase and ZIP+4 fail closed.
- **geo_latitude / geo_longitude / geo_coordinates** — reuse `ReducePrecision` (truncation, not rounding); integer-only and multi-dot fail closed; `geo_coordinates` lands a single allocation via the new `writeReducePrecision` builder-sink helper.

## Spec decisions pinned in code
- Truncation vs rounding: spec `-33.87***` is treated as typo; output is `-33.86*****`.
- `mobile_phone_number` is an alias for `phone_number`; the UK `07*** ***456` example is not honoured.
- `geo_coordinates` fails closed on any whitespace around the comma, multiple commas, or multi-dot halves.
- `MSISDN` with leading `+` fails closed — use `phone_number` for E.164.
- Postal codes only recognise UK/US/CA shapes; other locales fail closed.

## Test plan
- [x] `make check` clean (lint, vet, race, BDD strict, 97.4% coverage, govulncheck).
- [x] Per-rule unit tables covering canonical, fail-closed, boundary, empty, adversarial.
- [x] Cross-cutting matrices: `TestTelecom_FailClosedOnMalformed`, `TestTelecom_NoPanicOnAdversarialInput` (UTF-8 validity), `TestTelecom_IdempotencyMatrix`, `TestTelecom_MaskCharOverride`.
- [x] Security regression pins: trailing whitespace leak, multi-dot geo halves, leading-plus MSISDN, ambiguous postal shapes.
- [x] Benchmarks for every rule (1 alloc/op on hot paths; `geo_coordinates` tightened from 3 allocs → 1).
- [x] Reviewed by test-analyst, code-reviewer, security-reviewer, performance-reviewer, go-quality; every BLOCKING/CRITICAL finding applied (fix-don't-defer).

Partial progress on #4 (telecom subset). Remaining subset: country.