### PR TITLE
feat: add country-specific identity rules, close phase 4 (#4)

### DIFF
--- a/mask_test.go
+++ b/mask_test.go
@@ -16,8 +16,10 @@ package mask_test
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +28,13 @@ import (
 
 	"github.com/axonops/mask"
 )
+
+// packageLevelTestSeq supplies a monotonic suffix for tests that
+// register rules against the package-level registry. The package
+// registry has no Deregister method by design (registration is an
+// init-time concern); `-count=N` reruns would therefore collide on
+// a fixed name.
+var packageLevelTestSeq atomic.Uint64
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
@@ -202,7 +211,9 @@ func TestSetMaskChar_AppliesGlobally(t *testing.T) {
 func TestPackageLevel_RegisterApplyHasRuleDescribe(t *testing.T) {
 	// Intentionally NOT calling t.Parallel — the package-level registry is
 	// shared state; running serially keeps the naming stable across tests.
-	const name = "package_level_register_apply_rule"
+	// Unique suffix per invocation so -count=N reruns don't collide.
+	name := "package_level_register_apply_rule_" +
+		strconv.FormatUint(packageLevelTestSeq.Add(1), 10)
 	require.NoError(t, mask.Register(name, reverse))
 
 	assert.Equal(t, "cba", mask.Apply(name, "abc"))

--- a/rules_country.go
+++ b/rules_country.go
@@ -1,0 +1,529 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"strings"
+)
+
+// Country-category rules implement the 14 jurisdiction-specific
+// identifiers documented in docs/v0.9.0-requirements.md §"Personal
+// and Identity" from `us_ssn` through `es_dni_nif_nie`. Each rule
+// preserves a deterministic window (first N, last M, or both) and
+// routes malformed input to [SameLengthMask]. The rules are
+// registered under the `identity` category so `Describe()` answers
+// `identity` + a jurisdiction string.
+
+// ---------- shared separator predicates ----------
+
+// isHyphen reports whether r is an ASCII hyphen. Shared by rules
+// whose only separator is `-` (us_ssn, ca_sin).
+func isHyphen(r rune) bool { return r == '-' }
+
+// isSpace reports whether r is an ASCII space. Shared by rules
+// whose only separator is ` ` (uk_nino, in_aadhaar, au_medicare).
+func isSpace(r rune) bool { return r == ' ' }
+
+// isCPFSeparator reports whether r is `.` or `-` — CPF canonical
+// punctuation.
+func isCPFSeparator(r rune) bool { return r == '.' || r == '-' }
+
+// isCNPJSeparator reports whether r is `.`, `/`, or `-` — CNPJ
+// canonical punctuation.
+func isCNPJSeparator(r rune) bool { return r == '.' || r == '/' || r == '-' }
+
+// ---------- us_ssn ----------
+
+// maskUSSSN preserves the last 4 digits of a 9-digit US Social
+// Security Number. Accepts `AAAGGSSSS` or `AAA-GG-SSSS` with
+// hyphens at the canonical positions. Any other shape fails closed.
+func maskUSSSN(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidSSN(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 0, 4, 9, c, isHyphen)
+}
+
+// isValidSSN reports whether v is either 9 ASCII digits, or
+// `AAA-GG-SSSS` (3-2-4 with hyphens at positions 3 and 6).
+func isValidSSN(v string) bool {
+	switch len(v) {
+	case 9:
+		return allASCIIDigits(v)
+	case 11:
+		return v[3] == '-' && v[6] == '-' &&
+			allASCIIDigits(v[:3]) && allASCIIDigits(v[4:6]) && allASCIIDigits(v[7:])
+	}
+	return false
+}
+
+// ---------- ca_sin ----------
+
+// maskCASIN preserves the last 3 digits of a 9-digit Canadian
+// Social Insurance Number. Accepts `AAABBBCCC` or `AAA-BBB-CCC`.
+func maskCASIN(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidCASIN(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 0, 3, 9, c, isHyphen)
+}
+
+func isValidCASIN(v string) bool {
+	switch len(v) {
+	case 9:
+		return allASCIIDigits(v)
+	case 11:
+		return v[3] == '-' && v[7] == '-' &&
+			allASCIIDigits(v[:3]) && allASCIIDigits(v[4:7]) && allASCIIDigits(v[8:])
+	}
+	return false
+}
+
+// ---------- uk_nino ----------
+
+// maskUKNINO preserves the 2 prefix letters and 1 suffix letter
+// of a UK National Insurance Number; masks the 6 middle digits.
+// Accepts the compact form `AB123456C` and the spaced form
+// `AB 12 34 56 C`.
+func maskUKNINO(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidUKNINO(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 2, 1, 9, c, isSpace)
+}
+
+func isValidUKNINO(v string) bool {
+	switch len(v) {
+	case 9:
+		return isCompactUKNINO(v)
+	case 13:
+		return isSpacedUKNINO(v)
+	}
+	return false
+}
+
+// isCompactUKNINO reports whether v is a 9-byte UK NINO with no
+// separators: 2 upper letters + 6 digits + 1 upper letter.
+func isCompactUKNINO(v string) bool {
+	return isASCIIUpperLetter(v[0]) && isASCIIUpperLetter(v[1]) &&
+		allASCIIDigits(v[2:8]) && isASCIIUpperLetter(v[8])
+}
+
+// isSpacedUKNINO reports whether v is a 13-byte UK NINO in the
+// `AB 12 34 56 C` space-separated form.
+func isSpacedUKNINO(v string) bool {
+	if v[2] != ' ' || v[5] != ' ' || v[8] != ' ' || v[11] != ' ' {
+		return false
+	}
+	return isASCIIUpperLetter(v[0]) && isASCIIUpperLetter(v[1]) &&
+		allASCIIDigits(v[3:5]) && allASCIIDigits(v[6:8]) && allASCIIDigits(v[9:11]) &&
+		isASCIIUpperLetter(v[12])
+}
+
+// ---------- in_aadhaar ----------
+
+// maskINAadhaar preserves the last 4 digits of a 12-digit Aadhaar.
+// Accepts compact `123456789012` or grouped `1234 5678 9012`.
+func maskINAadhaar(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidAadhaar(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 0, 4, 12, c, isSpace)
+}
+
+func isValidAadhaar(v string) bool {
+	switch len(v) {
+	case 12:
+		return allASCIIDigits(v)
+	case 14:
+		return v[4] == ' ' && v[9] == ' ' &&
+			allASCIIDigits(v[:4]) && allASCIIDigits(v[5:9]) && allASCIIDigits(v[10:])
+	}
+	return false
+}
+
+// ---------- in_pan ----------
+
+// maskINPAN preserves the first 3 and last 2 characters of a
+// 10-character Indian Permanent Account Number. Shape is 5 upper
+// letters + 4 digits + 1 upper letter.
+func maskINPAN(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidINPAN(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, 3, 2, c)
+}
+
+func isValidINPAN(v string) bool {
+	if len(v) != 10 {
+		return false
+	}
+	for i := 0; i < 5; i++ {
+		if !isASCIIUpperLetter(v[i]) {
+			return false
+		}
+	}
+	if !allASCIIDigits(v[5:9]) {
+		return false
+	}
+	return isASCIIUpperLetter(v[9])
+}
+
+// ---------- au_medicare_number ----------
+
+// maskAUMedicareNumber preserves the last 2 digits of a 10-digit
+// Australian Medicare number. Accepts compact `1234567890` or the
+// canonical grouped `2123 45670 1` form (the spec example).
+//
+// Spec text says "Preserve last 3-4 digits" but the spec example
+// `2123 45670 1 → **** ****0 1` keeps only the trailing 2 digits
+// (the final group's single digit + the masked group's tail digit).
+// We honour the example.
+func maskAUMedicareNumber(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidAUMedicare(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 0, 2, 10, c, isSpace)
+}
+
+func isValidAUMedicare(v string) bool {
+	switch len(v) {
+	case 10:
+		return allASCIIDigits(v)
+	case 12:
+		// `NNNN NNNNN N` — 4 digits, space, 5 digits, space, 1 digit.
+		return v[4] == ' ' && v[10] == ' ' &&
+			allASCIIDigits(v[:4]) && allASCIIDigits(v[5:10]) && allASCIIDigits(v[11:])
+	}
+	return false
+}
+
+// ---------- sg_nric_fin ----------
+
+// maskSGNRICFIN preserves the leading letter and the trailing
+// letter of a Singapore NRIC/FIN (9 characters total: 1 letter + 7
+// digits + 1 letter).
+func maskSGNRICFIN(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidSGNRIC(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, 1, 1, c)
+}
+
+func isValidSGNRIC(v string) bool {
+	if len(v) != 9 {
+		return false
+	}
+	return isASCIIUpperLetter(v[0]) && allASCIIDigits(v[1:8]) && isASCIIUpperLetter(v[8])
+}
+
+// ---------- br_cpf ----------
+
+// maskBRCPF preserves the last 2 digits of an 11-digit Brazilian
+// CPF (taxpayer identifier). Accepts compact `12345678909` or
+// canonical `123.456.789-09`. Keeping the last 2 matches the
+// check-digit segment of the canonical form and the first spec
+// example; the unformatted spec example `12345678909 →
+// *******8909` (last 4) is treated as an inconsistency.
+func maskBRCPF(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidBRCPF(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 0, 2, 11, c, isCPFSeparator)
+}
+
+func isValidBRCPF(v string) bool {
+	switch len(v) {
+	case 11:
+		return allASCIIDigits(v)
+	case 14:
+		return v[3] == '.' && v[7] == '.' && v[11] == '-' &&
+			allASCIIDigits(v[:3]) && allASCIIDigits(v[4:7]) &&
+			allASCIIDigits(v[8:11]) && allASCIIDigits(v[12:])
+	}
+	return false
+}
+
+// ---------- br_cnpj ----------
+
+// maskBRCNPJ preserves the last 2 digits of a 14-digit Brazilian
+// CNPJ (business taxpayer identifier). Accepts compact
+// `12345678000195` or canonical `12.345.678/0001-95`. Keeping the
+// last 2 matches the spec example and the check-digit segment of
+// the canonical form; the spec's "last 4" text is treated as
+// inconsistent with the example.
+func maskBRCNPJ(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidBRCNPJ(v) {
+		return SameLengthMask(v, c)
+	}
+	return keepFirstLastNonSepCounted(v, 0, 2, 14, c, isCNPJSeparator)
+}
+
+func isValidBRCNPJ(v string) bool {
+	switch len(v) {
+	case 14:
+		return allASCIIDigits(v)
+	case 18:
+		return isFormattedBRCNPJ(v)
+	}
+	return false
+}
+
+// isFormattedBRCNPJ validates the canonical 18-byte CNPJ form
+// `NN.NNN.NNN/NNNN-NN`.
+func isFormattedBRCNPJ(v string) bool {
+	if v[2] != '.' || v[6] != '.' || v[10] != '/' || v[15] != '-' {
+		return false
+	}
+	return allASCIIDigits(v[:2]) && allASCIIDigits(v[3:6]) &&
+		allASCIIDigits(v[7:10]) && allASCIIDigits(v[11:15]) &&
+		allASCIIDigits(v[16:])
+}
+
+// ---------- mx_curp ----------
+
+// maskMXCURP preserves the first 4 characters (initials block) and
+// the last 3 characters (check digits) of a Mexican CURP; the 11
+// middle characters are masked. Total length is 18.
+//
+// The spec example `GAPA850101HDFRRL09 → GAPA**********L09` shows
+// 10 stars — we emit 11 to preserve same-length output. The spec
+// is treated as a typo (10-star output would be 17 chars for an
+// 18-char input).
+func maskMXCURP(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidMXCURP(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, 4, 3, c)
+}
+
+func isValidMXCURP(v string) bool {
+	if len(v) != 18 {
+		return false
+	}
+	for i := 0; i < 18; i++ {
+		if !isCURPByte(v[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isCURPByte reports whether b is a valid CURP character — upper
+// ASCII letter or digit.
+func isCURPByte(b byte) bool {
+	return isASCIIUpperLetter(b) || isASCIIDecDigit(b)
+}
+
+// ---------- mx_rfc ----------
+
+// maskMXRFC preserves the first 3 and last 3 characters of a
+// Mexican RFC. Accepts 12- or 13-character inputs (companies use
+// 12, individuals 13).
+func maskMXRFC(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidMXRFC(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, 3, 3, c)
+}
+
+func isValidMXRFC(v string) bool {
+	n := len(v)
+	if n != 12 && n != 13 {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if !isCURPByte(v[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------- cn_resident_id ----------
+
+// maskCNResidentID preserves the first 6 (region code) and last 4
+// characters of an 18-character PRC Resident Identity Card number.
+// The 17th position can be a digit or `X` (check digit for cards
+// whose check value is 10); all other positions are digits.
+func maskCNResidentID(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if !isValidCNResidentID(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, 6, 4, c)
+}
+
+func isValidCNResidentID(v string) bool {
+	if len(v) != 18 {
+		return false
+	}
+	for i := 0; i < 17; i++ {
+		if !isASCIIDecDigit(v[i]) {
+			return false
+		}
+	}
+	last := v[17]
+	return isASCIIDecDigit(last) || last == 'X' || last == 'x'
+}
+
+// ---------- za_national_id ----------
+
+// maskZANationalID preserves the first 6 (date of birth YYMMDD)
+// and last 4 characters of a 13-digit South African national ID
+// number.
+func maskZANationalID(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if len(v) != 13 || !allASCIIDigits(v) {
+		return SameLengthMask(v, c)
+	}
+	return KeepFirstLast(v, 6, 4, c)
+}
+
+// ---------- es_dni_nif_nie ----------
+
+// maskESDNINIFNIE preserves the leading character (letter prefix
+// for NIE inputs like `X1234567L`) only when present, and always
+// preserves the trailing control letter. DNIs (`12345678Z`) have
+// no leading letter; NIE/NIF inputs may. The input is 9 characters
+// in all forms.
+func maskESDNINIFNIE(v string, c rune) string {
+	if v == "" {
+		return ""
+	}
+	if len(v) != 9 {
+		return SameLengthMask(v, c)
+	}
+	lastLetter := isASCIIUpperLetter(v[8])
+	if !lastLetter {
+		return SameLengthMask(v, c)
+	}
+	// DNI: 8 digits + letter; no leading letter.
+	if allASCIIDigits(v[:8]) {
+		return KeepLastN(v, 1, c)
+	}
+	// NIE/NIF: leading letter + 7 digits + letter.
+	if isASCIIUpperLetter(v[0]) && allASCIIDigits(v[1:8]) {
+		return KeepFirstLast(v, 1, 1, c)
+	}
+	return SameLengthMask(v, c)
+}
+
+// ---------- registration ----------
+
+// registerCountryRules wires every rule in this file against m.
+func registerCountryRules(m *Masker) {
+	// Keep this table-driven so a reader can see the full catalogue
+	// at a glance and spot missing registrations quickly.
+	table := []struct {
+		name, jurisdiction, description string
+		fn                              func(v string, c rune) string
+	}{
+		{"us_ssn", "United States",
+			"Preserves the last 4 digits of a 9-digit US SSN; accepts `AAA-GG-SSSS` and `AAAGGSSSS`. Example: 123-45-6789 → ***-**-6789.",
+			maskUSSSN},
+		{"ca_sin", "Canada",
+			"Preserves the last 3 digits of a 9-digit Canadian SIN; accepts `AAA-BBB-CCC` and `AAABBBCCC`. Example: 123-456-789 → ***-***-789.",
+			maskCASIN},
+		{"uk_nino", "United Kingdom",
+			"Preserves the 2 prefix letters and 1 suffix letter of a UK NINO; masks the 6 middle digits. Accepts `AB123456C` and `AB 12 34 56 C`. Example: AB123456C → AB******C.",
+			maskUKNINO},
+		{"in_aadhaar", "India",
+			"Preserves the last 4 digits of a 12-digit Aadhaar number; accepts `123456789012` and `1234 5678 9012`. Example: 1234 5678 9012 → **** **** 9012.",
+			maskINAadhaar},
+		{"in_pan", "India",
+			"Preserves the first 3 and last 2 characters of a 10-character Indian PAN. Example: ABCDE1234F → ABC*****4F.",
+			maskINPAN},
+		{"au_medicare_number", "Australia",
+			"Preserves the last 2 digits of a 10-digit Australian Medicare number; accepts grouped `2123 45670 1` and compact `2123456701`. Example: 2123 45670 1 → **** ****0 1.",
+			maskAUMedicareNumber},
+		{"sg_nric_fin", "Singapore",
+			"Preserves the leading letter and trailing letter of a 9-character Singapore NRIC/FIN. Example: S1234567A → S*******A.",
+			maskSGNRICFIN},
+		{"br_cpf", "Brazil",
+			"Preserves the last 2 digits of an 11-digit Brazilian CPF; accepts compact and canonical forms. Example: 123.456.789-09 → ***.***.***-09.",
+			maskBRCPF},
+		{"br_cnpj", "Brazil",
+			"Preserves the last 2 digits of a 14-digit Brazilian CNPJ; accepts compact and canonical forms. Example: 12.345.678/0001-95 → **.***.***/****-95.",
+			maskBRCNPJ},
+		{"mx_curp", "Mexico",
+			"Preserves the first 4 and last 3 characters of an 18-character Mexican CURP. Example: GAPA850101HDFRRL09 → GAPA***********L09.",
+			maskMXCURP},
+		{"mx_rfc", "Mexico",
+			"Preserves the first 3 and last 3 characters of a 12- or 13-character Mexican RFC. Example: GAPA8501014T3 → GAP*******4T3.",
+			maskMXRFC},
+		{"cn_resident_id", "China",
+			"Preserves the first 6 (region code) and last 4 characters of an 18-character PRC Resident Identity Card number; the final character may be `X`. Example: 110101199003074578 → 110101********4578.",
+			maskCNResidentID},
+		{"za_national_id", "South Africa",
+			"Preserves the first 6 (date of birth) and last 4 digits of a 13-digit South African national ID. Example: 8501015009087 → 850101***9087.",
+			maskZANationalID},
+		{"es_dni_nif_nie", "Spain",
+			"Preserves the trailing control letter (and the leading letter for NIE/NIF inputs) of a 9-character Spanish DNI/NIF/NIE; masks the numeric body. Example: 12345678Z → ********Z.",
+			maskESDNINIFNIE},
+	}
+	for _, r := range table {
+		fn := r.fn
+		m.mustRegisterBuiltin(r.name,
+			func(v string) string { return fn(v, m.maskChar()) },
+			RuleInfo{
+				Name:         r.name,
+				Category:     "identity",
+				Jurisdiction: r.jurisdiction,
+				Description:  strings.TrimSpace(r.description),
+			})
+	}
+}
+
+func init() {
+	builtinRegistrars = append(builtinRegistrars, registerCountryRules)
+}

--- a/rules_country_bench_test.go
+++ b/rules_country_bench_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import "testing"
+
+// ---------- us_ssn / ca_sin / uk_nino ----------
+
+func BenchmarkApply_us_ssn(b *testing.B)         { runBench(b, "us_ssn", "123-45-6789") }
+func BenchmarkApply_us_ssn_compact(b *testing.B) { runBench(b, "us_ssn", "123456789") }
+func BenchmarkApply_us_ssn_invalid(b *testing.B) { runBench(b, "us_ssn", "not-a-ssn") }
+func BenchmarkApply_ca_sin(b *testing.B)         { runBench(b, "ca_sin", "123-456-789") }
+func BenchmarkApply_uk_nino(b *testing.B)        { runBench(b, "uk_nino", "AB123456C") }
+func BenchmarkApply_uk_nino_spaced(b *testing.B) { runBench(b, "uk_nino", "AB 12 34 56 C") }
+
+// ---------- in_aadhaar / in_pan ----------
+
+func BenchmarkApply_in_aadhaar(b *testing.B) { runBench(b, "in_aadhaar", "1234 5678 9012") }
+func BenchmarkApply_in_pan(b *testing.B)     { runBench(b, "in_pan", "ABCDE1234F") }
+
+// ---------- au_medicare_number / sg_nric_fin ----------
+
+func BenchmarkApply_au_medicare_number(b *testing.B) {
+	runBench(b, "au_medicare_number", "2123 45670 1")
+}
+func BenchmarkApply_sg_nric_fin(b *testing.B) { runBench(b, "sg_nric_fin", "S1234567A") }
+
+// ---------- br_cpf / br_cnpj ----------
+
+func BenchmarkApply_br_cpf(b *testing.B)  { runBench(b, "br_cpf", "123.456.789-09") }
+func BenchmarkApply_br_cnpj(b *testing.B) { runBench(b, "br_cnpj", "12.345.678/0001-95") }
+
+// ---------- mx_curp / mx_rfc ----------
+
+func BenchmarkApply_mx_curp(b *testing.B) { runBench(b, "mx_curp", "GAPA850101HDFRRL09") }
+func BenchmarkApply_mx_rfc(b *testing.B)  { runBench(b, "mx_rfc", "GAPA8501014T3") }
+
+// ---------- cn_resident_id / za_national_id / es_dni_nif_nie ----------
+
+func BenchmarkApply_cn_resident_id(b *testing.B) {
+	runBench(b, "cn_resident_id", "110101199003074578")
+}
+func BenchmarkApply_za_national_id(b *testing.B) {
+	runBench(b, "za_national_id", "8501015009087")
+}
+func BenchmarkApply_es_dni_nif_nie_dni(b *testing.B) {
+	runBench(b, "es_dni_nif_nie", "12345678Z")
+}
+func BenchmarkApply_es_dni_nif_nie_nie(b *testing.B) {
+	runBench(b, "es_dni_nif_nie", "X1234567L")
+}
+
+// ---------- fallback / fail-closed hot path ----------
+//
+// These benchmarks measure the SameLengthMask fallback for the
+// longer validators — the hot path taken when an adversarial or
+// malformed value is passed in. Regressions here would suggest the
+// validators are allocating on the failure branch.
+
+func BenchmarkApply_ca_sin_invalid(b *testing.B)     { runBench(b, "ca_sin", "not-a-sin") }
+func BenchmarkApply_uk_nino_invalid(b *testing.B)    { runBench(b, "uk_nino", "not-a-nino") }
+func BenchmarkApply_in_aadhaar_invalid(b *testing.B) { runBench(b, "in_aadhaar", "not an aadhaar") }
+func BenchmarkApply_br_cnpj_invalid(b *testing.B)    { runBench(b, "br_cnpj", "not-a-cnpj-number") }
+func BenchmarkApply_mx_curp_invalid(b *testing.B)    { runBench(b, "mx_curp", "gapa850101hdfrrl09") }
+func BenchmarkApply_cn_resident_id_invalid(b *testing.B) {
+	runBench(b, "cn_resident_id", "1101011990030745Y8")
+}

--- a/rules_country_test.go
+++ b/rules_country_test.go
@@ -1,0 +1,575 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/mask"
+)
+
+// countryRuleNames is the authoritative list used by cross-cutting
+// matrices below and by TestDescribe_CountryRules.
+var countryRuleNames = []string{
+	"us_ssn", "ca_sin", "uk_nino", "in_aadhaar", "in_pan",
+	"au_medicare_number", "sg_nric_fin", "br_cpf", "br_cnpj",
+	"mx_curp", "mx_rfc", "cn_resident_id", "za_national_id",
+	"es_dni_nif_nie",
+}
+
+// ---------- us_ssn ----------
+
+func TestApply_USSSN(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec hyphenated", "123-45-6789", "***-**-6789"},
+		{"spec compact", "123456789", "*****6789"},
+		{"empty", "", ""},
+		{"wrong hyphen positions fails closed", "12-345-6789", "***********"},
+		{"eight digits fails closed", "12345678", "********"},
+		{"ten digits fails closed", "1234567890", "**********"},
+		{"letters fail closed", "abc-de-6789", "***********"},
+		// Real-world variants: extraneous whitespace is not accepted
+		// by the canonical-shape validator — must fail closed.
+		{"leading whitespace fails closed", " 123-45-6789", "************"},
+		{"trailing whitespace fails closed", "123-45-6789 ", "************"},
+		{"tab separator fails closed", "123\t45\t6789", "***********"},
+		{"embedded nul fails closed", "123-45-67\x0089", "************"},
+		// Only hyphen is a valid separator — en-dash and Unicode
+		// minus must fail closed.
+		{"en-dash separators fail closed", "123\u201345\u20136789", "***********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("us_ssn", tc.in))
+		})
+	}
+}
+
+// ---------- ca_sin ----------
+
+func TestApply_CASIN(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec hyphenated", "123-456-789", "***-***-789"},
+		{"spec compact", "123456789", "******789"},
+		{"empty", "", ""},
+		{"wrong hyphen positions fails closed", "1234-56-789", "***********"},
+		{"eight digits fails closed", "12345678", "********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("ca_sin", tc.in))
+		})
+	}
+}
+
+// ---------- uk_nino ----------
+
+func TestApply_UKNINO(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec compact", "AB123456C", "AB******C"},
+		{"spec spaced", "AB 12 34 56 C", "AB ** ** ** C"},
+		{"empty", "", ""},
+		{"lowercase fails closed", "ab123456c", "*********"},
+		{"no suffix fails closed", "AB1234567", "*********"},
+		{"no prefix fails closed", "1B123456C", "*********"},
+		{"too short fails closed", "AB12345C", "********"},
+		{"missing space fails closed", "AB1234 56 C", "***********"},
+		// Spaced form with wrong space positions must fail closed —
+		// exercises the isSpacedUKNINO early-exit branch where v is
+		// 13 bytes but the spacer indexes are wrong.
+		{"spaced wrong positions fails closed", "A B12 34 56C ", "*************"},
+		// Real-world hyphenated form is not accepted.
+		{"hyphenated fails closed", "AB-12-34-56-C", "*************"},
+		// Trailing lowercase suffix letter fails closed.
+		{"compact trailing lowercase fails closed", "AB123456c", "*********"},
+		// NINO with lowercase leading letters (common copy-paste).
+		{"spaced lowercase fails closed", "ab 12 34 56 C", "*************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("uk_nino", tc.in))
+		})
+	}
+}
+
+// ---------- in_aadhaar ----------
+
+func TestApply_INAadhaar(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec grouped", "1234 5678 9012", "**** **** 9012"},
+		{"spec compact", "123456789012", "********9012"},
+		{"empty", "", ""},
+		{"eleven digits fails closed", "12345678901", "***********"},
+		{"wrong grouping fails closed", "12345 6789 012", "**************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("in_aadhaar", tc.in))
+		})
+	}
+}
+
+// ---------- in_pan ----------
+
+func TestApply_INPAN(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "ABCDE1234F", "ABC*****4F"},
+		{"empty", "", ""},
+		{"lowercase fails closed", "abcde1234f", "**********"},
+		{"wrong letter count fails closed", "ABCD1234FG", "**********"},
+		{"nine chars fails closed", "ABCDE1234", "*********"},
+		// Letters where digits should be — exercises the v[5:9]
+		// all-digits branch of isValidINPAN that was otherwise
+		// unreachable via other cases.
+		{"letters in digit block fails closed", "ABCDEXXXXF", "**********"},
+		// Trailing position must be an upper letter.
+		{"trailing digit fails closed", "ABCDE12345", "**********"},
+		// Lowercase trailing letter.
+		{"trailing lowercase fails closed", "ABCDE1234f", "**********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("in_pan", tc.in))
+		})
+	}
+}
+
+// ---------- au_medicare_number ----------
+
+func TestApply_AUMedicareNumber(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec grouped", "2123 45670 1", "**** ****0 1"},
+		{"compact", "2123456701", "********01"},
+		{"empty", "", ""},
+		{"nine digits fails closed", "212345670", "*********"},
+		{"wrong grouping fails closed", "21234 5670 1", "************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("au_medicare_number", tc.in))
+		})
+	}
+}
+
+// ---------- sg_nric_fin ----------
+
+func TestApply_SGNRICFIN(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "S1234567A", "S*******A"},
+		{"lowercase fails closed", "s1234567a", "*********"},
+		{"empty", "", ""},
+		{"too short fails closed", "S123A", "*****"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("sg_nric_fin", tc.in))
+		})
+	}
+}
+
+// ---------- br_cpf ----------
+
+func TestApply_BRCPF(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		// spec canonical: keep last 2 digits
+		{"spec canonical formatted", "123.456.789-09", "***.***.***-09"},
+		// deliberate deviation from the spec's unformatted example:
+		// the spec shows last-4-kept (`*******8909`) for the same
+		// rule that keeps last-2 for the formatted case. We honour
+		// "last 2" consistently to match the check-digit convention.
+		{"compact keeps last 2", "12345678909", "*********09"},
+		// Leading-zero CPFs are valid and common (CPF check digits
+		// permit any 2-digit prefix).
+		{"leading zero formatted", "001.234.567-89", "***.***.***-89"},
+		{"leading zero compact", "00123456789", "*********89"},
+		{"empty", "", ""},
+		{"ten digits fails closed", "1234567890", "**********"},
+		{"wrong punctuation fails closed", "123-456-789.09", "**************"},
+		// Only `.` and `-` are canonical CPF separators — spaces
+		// and slashes must fail closed.
+		{"spaced fails closed", "123 456 789 09", "**************"},
+		{"slash fails closed", "123/456/789-09", "**************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("br_cpf", tc.in))
+		})
+	}
+}
+
+// ---------- br_cnpj ----------
+
+func TestApply_BRCNPJ(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "12.345.678/0001-95", "**.***.***/****-95"},
+		{"compact keeps last 2", "12345678000195", "************95"},
+		{"empty", "", ""},
+		{"wrong length fails closed", "12.345.678/0001-9", "*****************"},
+		// Exercises the isFormattedBRCNPJ early-exit where v is
+		// 18 bytes but one of the punctuation positions is wrong.
+		{"wrong punctuation fails closed", "12-345.678/0001-95", "******************"},
+		{"dash instead of slash fails closed", "12.345.678-0001-95", "******************"},
+		// Digit where punctuation is expected.
+		{"digit at separator fails closed", "123456.678/0001-95", "******************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("br_cnpj", tc.in))
+		})
+	}
+}
+
+// ---------- mx_curp ----------
+
+func TestApply_MXCURP(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		// Spec's 10-star output would be 17 chars for an 18-char
+		// input; we emit 11 stars to preserve same-length output.
+		{"spec same-length", "GAPA850101HDFRRL09", "GAPA***********L09"},
+		{"empty", "", ""},
+		{"lowercase fails closed", "gapa850101hdfrrl09", "******************"},
+		{"wrong length fails closed", "GAPA850101HDFRRL0", "*****************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("mx_curp", tc.in))
+		})
+	}
+}
+
+// ---------- mx_rfc ----------
+
+func TestApply_MXRFC(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec individual 13", "GAPA8501014T3", "GAP*******4T3"},
+		{"company 12", "ABC850101DEF", "ABC******DEF"},
+		// Anonymous foreign-buyer RFC — all digits in the middle.
+		{"anonymous foreign buyer", "XAXX010101000", "XAX*******000"},
+		{"empty", "", ""},
+		{"wrong length fails closed", "ABC", "***"},
+		{"length 11 fails closed", "GAPA850101D", "***********"},
+		{"length 14 fails closed", "GAPA850101DEFG", "**************"},
+		{"lowercase fails closed", "gapa8501014t3", "*************"},
+		{"contains hyphen fails closed", "GAPA-85010-14T3", "***************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("mx_rfc", tc.in))
+		})
+	}
+}
+
+// ---------- cn_resident_id ----------
+
+func TestApply_CNResidentID(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "110101199003074578", "110101********4578"},
+		{"last char X uppercase", "11010119900307457X", "110101********457X"},
+		{"last char x lowercase", "11010119900307457x", "110101********457x"},
+		{"empty", "", ""},
+		{"seventeen digits fails closed", "11010119900307457", "*****************"},
+		{"non-digit in body fails closed", "1101011990030745X8", "******************"},
+		// Real-world variants: hyphen-grouped Chinese IDs are not
+		// a canonical form — must fail closed.
+		{"hyphenated fails closed", "110101-19900307-457X", "********************"},
+		{"leading whitespace fails closed", " 110101199003074578", "*******************"},
+		{"letter other than X fails closed", "11010119900307457Y", "******************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("cn_resident_id", tc.in))
+		})
+	}
+}
+
+// ---------- za_national_id ----------
+
+func TestApply_ZANationalID(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec canonical", "8501015009087", "850101***9087"},
+		{"empty", "", ""},
+		{"twelve digits fails closed", "850101500908", "************"},
+		{"fourteen digits fails closed", "85010150090876", "**************"},
+		{"letters fail closed", "8501015ABC087", "*************"},
+		// Real-world variants: spaced or hyphenated forms are not
+		// accepted — must fail closed.
+		{"spaced fails closed", "850101 5009 087", "***************"},
+		{"hyphenated fails closed", "850101-5009-087", "***************"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("za_national_id", tc.in))
+		})
+	}
+}
+
+// ---------- es_dni_nif_nie ----------
+
+func TestApply_ESDNINIFNIE(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in, want string }{
+		{"spec dni", "12345678Z", "********Z"},
+		{"spec nie", "X1234567L", "X*******L"},
+		{"nie with Y prefix", "Y1234567M", "Y*******M"},
+		{"nie with Z prefix", "Z1234567N", "Z*******N"},
+		{"empty", "", ""},
+		{"missing trailing letter fails closed", "123456789", "*********"},
+		{"lowercase trailing fails closed", "12345678z", "*********"},
+		{"letter in middle fails closed", "12A45678Z", "*********"},
+		// 9 characters but neither DNI (8 digits + letter) nor NIE
+		// (letter + 7 digits + letter) — all upper letters for
+		// example. Exercises the final SameLengthMask fallback of
+		// maskESDNINIFNIE after both shape branches miss.
+		{"all letters fails closed", "ABCDEFGHI", "*********"},
+		// Leading letter without 7 digits in body.
+		{"nie malformed body fails closed", "XAB34567L", "*********"},
+		// Real-world variant: hyphenated DNI is not accepted.
+		{"hyphenated fails closed", "12345678-Z", "**********"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply("es_dni_nif_nie", tc.in))
+		})
+	}
+}
+
+// ---------- mask-character override ----------
+
+func TestCountry_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	cases := []struct{ rule, in, want string }{
+		{"us_ssn", "123-45-6789", "XXX-XX-6789"},
+		{"ca_sin", "123-456-789", "XXX-XXX-789"},
+		{"uk_nino", "AB123456C", "ABXXXXXXC"},
+		{"in_aadhaar", "1234 5678 9012", "XXXX XXXX 9012"},
+		{"in_pan", "ABCDE1234F", "ABCXXXXX4F"},
+		{"au_medicare_number", "2123 45670 1", "XXXX XXXX0 1"},
+		{"sg_nric_fin", "S1234567A", "SXXXXXXXA"},
+		{"br_cpf", "123.456.789-09", "XXX.XXX.XXX-09"},
+		{"br_cnpj", "12.345.678/0001-95", "XX.XXX.XXX/XXXX-95"},
+		{"mx_curp", "GAPA850101HDFRRL09", "GAPAXXXXXXXXXXXL09"},
+		{"mx_rfc", "GAPA8501014T3", "GAPXXXXXXX4T3"},
+		{"cn_resident_id", "110101199003074578", "110101XXXXXXXX4578"},
+		{"za_national_id", "8501015009087", "850101XXX9087"},
+		{"es_dni_nif_nie", "12345678Z", "XXXXXXXXZ"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply(tc.rule, tc.in))
+		})
+	}
+}
+
+// ---------- registrations and metadata ----------
+
+func TestDescribe_CountryRules(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	for _, n := range countryRuleNames {
+		t.Run(n, func(t *testing.T) {
+			info, ok := m.Describe(n)
+			require.True(t, ok, "rule %q not registered", n)
+			assert.Equal(t, "identity", info.Category)
+			assert.NotEmpty(t, info.Jurisdiction)
+			assert.Equal(t, n, info.Name)
+			assert.Contains(t, info.Description, "Example:",
+				"rule %q description must include an Example", n)
+		})
+	}
+}
+
+// TestCountry_FailClosedOnMalformed confirms every rule produces a
+// same-length mask on a malformed input and never echoes the input.
+func TestCountry_FailClosedOnMalformed(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	malformed := "totally-not-a-jurisdictional-id-xyz"
+	for _, n := range countryRuleNames {
+		t.Run(n, func(t *testing.T) {
+			got := m.Apply(n, malformed)
+			assert.NotEqual(t, malformed, got, "rule %q echoed malformed input", n)
+			assert.Equal(t, strings.Repeat("*", utf8.RuneCountInString(malformed)), got,
+				"rule %q did not produce same-length mask on malformed input", n)
+		})
+	}
+}
+
+// TestCountry_NoPanicOnAdversarialInput mirrors the phase 4a-e
+// contract — every rule must handle adversarial bytes without
+// panicking and emit well-formed UTF-8.
+//
+// The adversarial corpus deliberately includes invalid-UTF-8 byte
+// sequences at every canonical-shape length used by the country
+// validators (9, 10, 11, 12, 13, 14, 18) so that every length-
+// branch of every validator is probed with bytes that would pass
+// the length check but fail the content check.
+func TestCountry_NoPanicOnAdversarialInput(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	invalidUTF8 := func(n int) string {
+		return strings.Repeat("\xff", n)
+	}
+	adversarial := []string{
+		"",
+		"\xff\xfe\xfd",
+		"\x00",
+		strings.Repeat("9", 500),
+		"\u200B123-45-6789",
+		"\u202E123456789",
+		"AB 12 34 56 \u00a0C",
+		// Length-targeted invalid UTF-8 — one per canonical length.
+		invalidUTF8(9),  // us_ssn, ca_sin, uk_nino compact, sg_nric_fin, es_dni_nif_nie
+		invalidUTF8(10), // au_medicare_number compact, in_pan
+		invalidUTF8(11), // us_ssn spaced, ca_sin spaced, br_cpf compact
+		invalidUTF8(12), // au_medicare_number spaced, in_aadhaar compact, mx_rfc
+		invalidUTF8(13), // uk_nino spaced, mx_rfc, za_national_id
+		invalidUTF8(14), // in_aadhaar spaced, br_cpf formatted, br_cnpj compact
+		invalidUTF8(18), // mx_curp, br_cnpj formatted, cn_resident_id
+		// A surrogate half would be invalid if present — guarded
+		// by length checks in all rules.
+		"\xed\xa0\x80\xed\xa0\x80\xed\xa0\x80",
+	}
+	for _, n := range countryRuleNames {
+		for _, in := range adversarial {
+			var got string
+			assert.NotPanics(t, func() { got = m.Apply(n, in) },
+				"rule %q panicked on input %q", n, in)
+			assert.True(t, utf8.ValidString(got),
+				"rule %q produced invalid UTF-8 for input %q: %q", n, in, got)
+		}
+	}
+}
+
+// TestCountry_MaskCharOverride_FailClosed confirms the configured
+// mask rune flows through the fail-closed path as well as the
+// canonical path — a malformed input masked with override char 'X'
+// must be X-filled, not '*'-filled.
+func TestCountry_MaskCharOverride_FailClosed(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	malformed := "totally-not-an-id"
+	want := strings.Repeat("X", utf8.RuneCountInString(malformed))
+	for _, n := range countryRuleNames {
+		t.Run(n, func(t *testing.T) {
+			got := m.Apply(n, malformed)
+			assert.Equal(t, want, got,
+				"rule %q did not honour override mask rune on fallback", n)
+		})
+	}
+}
+
+// TestCountry_CountryRuleNamesDriftGuard ensures countryRuleNames —
+// the slice all cross-cutting matrices iterate over — stays in sync
+// with the actual registration table. If a new country rule is
+// added without adding it here, this test fails immediately; no
+// matrix is silently narrower than the catalogue.
+func TestCountry_CountryRuleNamesDriftGuard(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	for _, n := range countryRuleNames {
+		info, ok := m.Describe(n)
+		require.True(t, ok, "countryRuleNames entry %q is not registered", n)
+		require.Equal(t, "identity", info.Category,
+			"rule %q is in countryRuleNames but is not category=identity", n)
+		require.False(t, strings.HasPrefix(info.Jurisdiction, "global"),
+			"rule %q is in countryRuleNames but has global jurisdiction %q",
+			n, info.Jurisdiction)
+	}
+	// Inverse: every identity rule with a concrete (non-`global`)
+	// jurisdiction must be in countryRuleNames. Rules in
+	// rules_identity.go all carry `global` or `global (…)`.
+	names := map[string]bool{}
+	for _, n := range countryRuleNames {
+		names[n] = true
+	}
+	for _, ruleName := range m.Rules() {
+		info, ok := m.Describe(ruleName)
+		if !ok || info.Category != "identity" {
+			continue
+		}
+		if strings.HasPrefix(info.Jurisdiction, "global") || info.Jurisdiction == "" {
+			continue
+		}
+		assert.True(t, names[ruleName],
+			"rule %q has Jurisdiction=%q but is missing from countryRuleNames",
+			ruleName, info.Jurisdiction)
+	}
+}
+
+// TestCountry_IdempotencyMatrix: every rule is non-idempotent
+// because the mask rune is not a valid digit / letter in any of
+// the canonical-shape validators — a second pass collapses to
+// SameLengthMask.
+func TestCountry_IdempotencyMatrix(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ name, in string }{
+		{"us_ssn", "123-45-6789"},
+		{"ca_sin", "123-456-789"},
+		{"uk_nino", "AB123456C"},
+		{"in_aadhaar", "1234 5678 9012"},
+		{"in_pan", "ABCDE1234F"},
+		{"au_medicare_number", "2123 45670 1"},
+		{"sg_nric_fin", "S1234567A"},
+		{"br_cpf", "123.456.789-09"},
+		{"br_cnpj", "12.345.678/0001-95"},
+		{"mx_curp", "GAPA850101HDFRRL09"},
+		{"mx_rfc", "GAPA8501014T3"},
+		{"cn_resident_id", "110101199003074578"},
+		{"za_national_id", "8501015009087"},
+		{"es_dni_nif_nie", "12345678Z"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first := m.Apply(tc.name, tc.in)
+			second := m.Apply(tc.name, first)
+			assert.NotEqual(t, first, second,
+				"rule %q was expected to be non-idempotent", tc.name)
+		})
+	}
+}

--- a/tests/bdd/features/country.feature
+++ b/tests/bdd/features/country.feature
@@ -1,0 +1,198 @@
+@country
+Feature: Country-specific identity masking rules
+  The country catalogue covers 14 jurisdiction-specific identity
+  numbers from docs/v0.9.0-requirements.md §"Personal and Identity"
+  (us_ssn through es_dni_nif_nie). Each rule preserves a small
+  deterministic window (first N, last M, or both) appropriate to the
+  jurisdiction and masks the rest; every rule fails closed on
+  malformed input.
+
+  Scenario Outline: Mask US SSNs
+    Given a fresh masker
+    When I apply "us_ssn" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input        | expected     |
+      | 123-45-6789  | ***-**-6789  |
+      | 123456789    | *****6789    |
+      | 12345678     | ********     |
+      | 12-345-6789  | ***********  |
+      |              |              |
+
+  Scenario Outline: Mask Canadian SINs
+    Given a fresh masker
+    When I apply "ca_sin" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input       | expected    |
+      | 123-456-789 | ***-***-789 |
+      | 123456789   | ******789   |
+      |             |             |
+
+  Scenario Outline: Mask UK National Insurance Numbers
+    Given a fresh masker
+    When I apply "uk_nino" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input         | expected      |
+      | AB123456C     | AB******C     |
+      | AB 12 34 56 C | AB ** ** ** C |
+      | ab123456c     | *********     |
+      |               |               |
+
+  Scenario Outline: Mask Indian Aadhaar
+    Given a fresh masker
+    When I apply "in_aadhaar" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input          | expected       |
+      | 1234 5678 9012 | **** **** 9012 |
+      | 123456789012   | ********9012   |
+      |                |                |
+
+  Scenario Outline: Mask Indian PAN
+    Given a fresh masker
+    When I apply "in_pan" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input      | expected   |
+      | ABCDE1234F | ABC*****4F |
+      | abcde1234f | ********** |
+      |            |            |
+
+  Scenario Outline: Mask Australian Medicare numbers
+    # Spec text says "last 3-4 digits" but the spec example keeps
+    # the trailing 2 digits; we follow the example.
+    Given a fresh masker
+    When I apply "au_medicare_number" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input        | expected     |
+      | 2123 45670 1 | **** ****0 1 |
+      | 2123456701   | ********01   |
+      |              |              |
+
+  Scenario Outline: Mask Singapore NRIC/FIN
+    Given a fresh masker
+    When I apply "sg_nric_fin" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input     | expected  |
+      | S1234567A | S*******A |
+      | s1234567a | ********* |
+      |           |           |
+
+  Scenario Outline: Mask Brazilian CPF
+    Given a fresh masker
+    When I apply "br_cpf" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input          | expected       |
+      | 123.456.789-09 | ***.***.***-09 |
+      | 12345678909    | *********09    |
+      | 001.234.567-89 | ***.***.***-89 |
+      | 123/456/789-09 | ************** |
+      |                |                |
+
+  Scenario Outline: Mask Brazilian CNPJ
+    Given a fresh masker
+    When I apply "br_cnpj" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | expected           |
+      | 12.345.678/0001-95 | **.***.***/****-95 |
+      | 12345678000195     | ************95     |
+      |                    |                    |
+
+  Scenario Outline: Mask Mexican CURP
+    # Spec output is 17 chars for an 18-char input; we honour the
+    # library-wide same-length invariant and emit 18 chars.
+    Given a fresh masker
+    When I apply "mx_curp" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | expected           |
+      | GAPA850101HDFRRL09 | GAPA***********L09 |
+      |                    |                    |
+
+  Scenario Outline: Mask Mexican RFC
+    Given a fresh masker
+    When I apply "mx_rfc" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input         | expected      |
+      | GAPA8501014T3 | GAP*******4T3 |
+      | ABC850101DEF  | ABC******DEF  |
+      |               |               |
+
+  Scenario Outline: Mask Chinese Resident Identity Card numbers
+    Given a fresh masker
+    When I apply "cn_resident_id" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input              | expected           |
+      | 110101199003074578 | 110101********4578 |
+      | 11010119900307457X | 110101********457X |
+      | 11010119900307457x | 110101********457x |
+      | 11010119900307457Y | ****************** |
+      |                    |                    |
+
+  Scenario Outline: Mask South African national IDs
+    Given a fresh masker
+    When I apply "za_national_id" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input         | expected      |
+      | 8501015009087 | 850101***9087 |
+      | 850101500908  | ************  |
+      |               |               |
+
+  Scenario Outline: Mask Spanish DNI/NIF/NIE
+    Given a fresh masker
+    When I apply "es_dni_nif_nie" to "<input>"
+    Then the result is "<expected>"
+
+    Examples:
+      | input     | expected  |
+      | 12345678Z | ********Z |
+      | X1234567L | X*******L |
+      | Y1234567M | Y*******M |
+      | Z1234567N | Z*******N |
+      | 12345678z | ********* |
+      | ABCDEFGHI | ********* |
+      |           |           |
+
+  Scenario Outline: Every country rule handles empty input consistently
+    Given a fresh masker
+    When I apply "<rule>" to ""
+    Then the result is ""
+
+    Examples:
+      | rule               |
+      | us_ssn             |
+      | ca_sin             |
+      | uk_nino            |
+      | in_aadhaar         |
+      | in_pan             |
+      | au_medicare_number |
+      | sg_nric_fin        |
+      | br_cpf             |
+      | br_cnpj            |
+      | mx_curp            |
+      | mx_rfc             |
+      | cn_resident_id     |
+      | za_national_id     |
+      | es_dni_nif_nie     |


### PR DESCRIPTION
## Summary

Implements the final 14 jurisdiction-specific identity rules, completing Phase 4 of issue #4. All 6 category subsets (identity, financial, health, technology, telecom, country) are now merged.

- `us_ssn`, `ca_sin`, `uk_nino`, `in_aadhaar`, `in_pan`, `au_medicare_number`, `sg_nric_fin`, `br_cpf`, `br_cnpj`, `mx_curp`, `mx_rfc`, `cn_resident_id`, `za_national_id`, `es_dni_nif_nie`.
- Every rule registers under the `identity` category; each carries a specific `Jurisdiction` string (United States, Canada, United Kingdom, India, Australia, Singapore, Brazil, Mexico, China, South Africa, Spain) so `Describe()` answers accurately.
- Validators are ASCII byte loops; no regex. Fail-closed to `SameLengthMask` everywhere.

## Spec-vs-example inconsistencies pinned by policy (documented in code)
- `au_medicare_number` keeps last 2 (spec example shows 2; spec text says 3-4).
- `br_cpf` unformatted keeps last 2 consistently (spec showed last-4 for unformatted but last-2 for formatted — we pick last-2 to match the check-digit convention).
- `mx_curp` emits 11 mask runes (not spec's 10) to preserve the same-length invariant for its 18-char input.

## Also in this PR
- Fix for pre-existing `TestPackageLevel_RegisterApplyHasRuleDescribe` collision under `go test -count=N` — now uses an atomic counter suffix. Caught by the reviewers under the "whole codebase" rule.
- A drift-guard test that fails the build if a new country rule is registered but missed in the cross-cutting matrices.

## Test plan
- [x] `make check` clean (lint, vet, race, BDD strict, 97.7% coverage, govulncheck).
- [x] 14 per-rule unit tables covering canonical + fail-closed variants.
- [x] Cross-cutting matrices: fail-closed, adversarial (UTF-8 validity), idempotency, mask-char-override (happy + fail-closed), drift guard.
- [x] 20 benchmarks (1 alloc/op across the board).
- [x] Reviewed by test-analyst, code-reviewer, security-reviewer, performance-reviewer, go-quality. Every BLOCKING/IMPORTANT finding applied.

Closes #4.