### PR TITLE
refactor: phase 6 quality gate for v0.9.0 release (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,27 @@ jobs:
           fi
           echo "All ${#expected[@]} required Makefile targets are documented in 'make help'."
 
+  apache-header-guard:
+    name: Apache 2.0 header on every Go file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Verify Apache 2.0 header
+        run: |
+          set -euo pipefail
+          # Every tracked *.go file MUST carry the Apache 2.0 header in its
+          # first ~14 lines. The tell-tale phrase is stable across every
+          # file in the repo; grep -L lists files missing it.
+          missing=$(git ls-files '*.go' \
+            | xargs grep -L 'Licensed under the Apache License, Version 2.0' \
+            || true)
+          if [ -n "$missing" ]; then
+            echo "::error::Go files missing Apache 2.0 header:"
+            printf '%s\n' "$missing"
+            exit 1
+          fi
+          echo "All tracked .go files carry the Apache 2.0 header."
+
   local-paths-guard:
     name: No local paths or replace directives
     runs-on: ubuntu-latest
@@ -286,6 +307,14 @@ jobs:
       - name: Coverage
         if: matrix.os == 'ubuntu-latest'
         run: make coverage
+      - name: Enforce coverage threshold
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}' | tr -d '%')
+          threshold=90.0
+          echo "Total coverage: ${total}% (threshold ${threshold}%)"
+          awk -v t="$total" -v th="$threshold" 'BEGIN { if (t+0 < th+0) { exit 1 } }' \
+            || { echo "::error::coverage ${total}% < threshold ${threshold}%"; exit 1; }
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Disallow non-dry release from a non-main ref
+        if: github.ref != 'refs/heads/main' && inputs.dry_run != true
+        run: |
+          echo "::error::Non-dry releases must dispatch from main (got ${{ github.ref }}). Merge to main first, then re-dispatch."
+          exit 1
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
@@ -69,10 +74,14 @@ jobs:
     permissions:
       contents: write
     steps:
+      # On a real release the tag has just been pushed by the `tag`
+      # job, so we check it out. On a dry run no tag exists yet;
+      # fall back to the workflow's invocation ref so the build runs
+      # against the commit a human operator just validated.
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.dry_run && github.ref || inputs.tag }}
       - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
-Initial public release — `v0.9.0`.
+No unreleased changes.
+
+## [0.9.0] — 2026-04-18
+
+Initial public release.
 
 ### Added
 
 - **Core API.** `mask.Apply(name, value)` for rule lookup and invocation, `mask.Register(name, fn)` for custom rules on the package-level registry, `mask.New(opts...)` for per-instance isolated registries, and `mask.Rules()` / `mask.Describe(name)` for runtime catalogue discovery.
 - **Configurable mask character.** `mask.SetMaskChar(c)` for the package-level default and `mask.WithMaskChar(c)` for per-instance override.
 - **Utility primitives** — direct-call helpers (`FullRedact`, `Nullify`, `SameLengthMask`, `KeepFirstN`, `KeepLastN`, `KeepFirstLast`, `TruncateVisible`, `PreserveDelimiters`, `ReplaceRegex`, `ReducePrecision`, `DeterministicHash`) and factory wrappers (`KeepFirstNFunc`, `KeepLastNFunc`, `KeepFirstLastFunc`, `TruncateVisibleFunc`, `PreserveDelimitersFunc`, `ReplaceRegexFunc`, `ReducePrecisionFunc`, `FixedReplacementFunc`, `DeterministicHashFunc`).
-- **Deterministic hashing** with configurable algorithm (`SHA256`, `SHA512`, `SHA3_256`, `SHA3_512`) and mandatory salt version (`WithSalt`). Output format `sha256:<hex16>` unsalted, `sha256:<version>:<hex16>` salted.
+- **Deterministic hashing** with configurable algorithm (`SHA256`, `SHA512`, `SHA3_256`, `SHA3_512`) and independent salt + version options (`WithSalt`, `WithSaltVersion`). Output format `sha256:<hex16>` unsalted, `sha256:<version>:<hex16>` salted.
 - **68 built-in masking rules** across identity (11 global + 14 country-specific), financial (11), healthcare (5), technology (14), telecom (5), and location (4) categories. Every rule is fail-closed, honours the configured mask character, and is registered with a populated `RuleInfo` including category, jurisdiction, and an `input → output` example.
 - **Runnable godoc examples** covering the simplest `Apply` case, fail-closed behaviour, custom rule registration, per-instance mask-character override, global mask-character override, direct primitive calls, factory-based registration, runtime discovery via `Describe`, and a realistic structured-log redaction sample.
 - **Package documentation** (`doc.go`) covering the quick start, design principles, thread-safety contract, mask-character configuration, and explicit non-goals.
@@ -23,4 +27,5 @@ Initial public release — `v0.9.0`.
 - **CI/CD.** Format check, vet, lint, unit and BDD tests, coverage, module tidy, security scan, cross-platform builds (`linux/amd64`, `darwin/arm64`, `windows/amd64`), and a CI-only release workflow — no local tagging permitted.
 - `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (Apache 2.0).
 
-[Unreleased]: https://github.com/axonops/mask/commits/HEAD
+[Unreleased]: https://github.com/axonops/mask/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/axonops/mask/releases/tag/v0.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Before opening a PR, run the full quality gate (`make check`). Internally this p
 - Every masking rule and every primitive has at least one `Scenario Outline` with `Examples` covering canonical, formatted, malformed, empty, and (where applicable) unicode inputs.
 - Benchmarks live in `*_bench_test.go` files and call `b.ReportAllocs()`.
 
-See [`CLAUDE.md`][claude-md] (not in this repo — developer-local) and the `docs/v0.9.0-requirements.md` spec for the authoritative testing requirements.
+See `CLAUDE.md` (developer-local, not checked into the repo) and the `docs/v0.9.0-requirements.md` spec for the authoritative testing requirements.
 
 ## Code standards
 
@@ -100,4 +100,4 @@ See [`SECURITY.md`](./SECURITY.md) for vulnerability disclosure.
 
 By contributing, you agree that your contributions will be licensed under the [Apache Licence 2.0](./LICENSE).
 
-[claude-md]: CLAUDE.md
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Every built-in rule is fail-closed. Two guarantees you can rely on at every call
 - An unknown rule name returns `[REDACTED]` — the original value is never echoed.
 - A known rule that cannot parse its input returns a same-length mask — the original value is never echoed.
 
-`Apply` never returns an error. Masking is pure compute — no I/O, no goroutines, no context.
+`Apply` never returns an error. Masking is pure compute — no I/O, no goroutines, no context. `Register`, by contrast, returns `ErrDuplicateRule` or `ErrInvalidRule` on misuse — check it at init time.
 
 ## Why
 
@@ -216,7 +216,7 @@ Phone numbers, mobile identifiers, postcodes, and geographic coordinates.
 
 The masking primitives are also exposed as Go functions. Call them directly inside a custom `RuleFunc`, or use the `…Func` factory to register a parametric rule at any name of your choosing.
 
-> Factories (`KeepFirstNFunc`, `ReplaceRegexFunc`, etc.) capture `DefaultMaskChar` at construction and ignore per-instance overrides. Callers who need per-instance mask-character customisation should register a closure that reads `m.MaskChar()` at call time.
+> Factories (`KeepFirstNFunc`, `ReplaceRegexFunc`, etc.) capture `DefaultMaskChar` at construction and ignore per-instance overrides. Callers who need per-instance mask-character customisation should register a closure that captures the desired mask rune at construction time rather than using a factory.
 
 ### Direct-call helpers
 
@@ -236,56 +236,175 @@ The masking primitives are also exposed as Go functions. Call them directly insi
 
 ### Factory functions
 
-Each factory returns a `RuleFunc` suitable for passing to `Register`.
+Each factory returns a `RuleFunc` suitable for passing to `Register`. Every example below uses the default mask character `*`.
 
-| Factory | Returns a rule that... |
-|---|---|
-| `FixedReplacementFunc(s)` | Returns the literal string `s` regardless of input. |
-| `KeepFirstNFunc(n)` | Calls `KeepFirstN(v, n, DefaultMaskChar)`. |
-| `KeepLastNFunc(n)` | Calls `KeepLastN(v, n, DefaultMaskChar)`. |
-| `KeepFirstLastFunc(first, last)` | Calls `KeepFirstLast(v, first, last, DefaultMaskChar)`. |
-| `TruncateVisibleFunc(n)` | Calls `TruncateVisible(v, n)`. |
-| `PreserveDelimitersFunc(delim)` | Calls `PreserveDelimiters(v, delim, DefaultMaskChar)`. |
-| `ReplaceRegexFunc(pattern, replacement)` | Pre-compiles `pattern` once; returns `(nil, err)` on an invalid pattern. |
-| `ReducePrecisionFunc(decimals)` | Calls `ReducePrecision(v, decimals, DefaultMaskChar)`. |
-| `DeterministicHashFunc(opts...)` | Hashes via `DeterministicHash`; salt, version, and algorithm are configured via `HashOption` arguments. |
+| Factory | Behaviour | Example |
+|---|---|---|
+| `FixedReplacementFunc(s)` | Returns the literal string `s` regardless of input. | `FixedReplacementFunc("[HIDDEN]")("anything")` → `[HIDDEN]` |
+| `KeepFirstNFunc(n)` | Keeps the first `n` runes, masks the rest. | `KeepFirstNFunc(4)("Sensitive")` → `Sens*****` |
+| `KeepLastNFunc(n)` | Keeps the last `n` runes, masks the rest. | `KeepLastNFunc(4)("Sensitive")` → `*****tive` |
+| `KeepFirstLastFunc(first, last)` | Keeps both ends, masks the middle. | `KeepFirstLastFunc(4, 4)("SensitiveData")` → `Sens*****Data` |
+| `TruncateVisibleFunc(n)` | Returns the first `n` runes with no mask. Not fail-closed. | `TruncateVisibleFunc(4)("Sensitive")` → `Sens` |
+| `PreserveDelimitersFunc(delim)` | Masks every rune except those listed in `delim`. | `PreserveDelimitersFunc("-")("ab-cd")` → `**-**` |
+| `ReplaceRegexFunc(pattern, replacement)` | Pre-compiles `pattern` once; returns `(nil, err)` on an invalid pattern. | `ReplaceRegexFunc("\\d+", "N")` applied to `"id-42"` → `id-N` |
+| `ReducePrecisionFunc(decimals)` | Reduces decimal precision of a numeric string by masking trailing digits. | `ReducePrecisionFunc(2)("37.7749")` → `37.77**` |
+| `DeterministicHashFunc(opts...)` | Hashes via `DeterministicHash`; salt, version, and algorithm are configured via `HashOption` arguments. | `DeterministicHashFunc()("alice@example.com")` → `sha256:ff8d9819fc0e12bf` |
 
 See [`pkg.go.dev`](https://pkg.go.dev/github.com/axonops/mask) for the full API reference.
 
 ## Custom rules
 
-For formats the built-in catalogue does not cover, register a custom `RuleFunc` against the package-level registry. Most real rules compose one of the utility primitives — rarely do you need to write a masking algorithm from scratch.
+Registering your own rule is the extension point when the built-in catalogue does not cover a format. A rule is just a `RuleFunc` — `func(string) string` — registered under a name and then called via `Apply`. Most real rules compose one of the utility primitives; rarely do you need to write a masking algorithm from scratch.
+
+The five patterns below cover the situations you're likely to hit, in rough order of simplicity.
+
+### 1. Use a factory directly
+
+The `…Func` factories turn a primitive into a ready-to-register `RuleFunc` with no closure required. Best when the masking shape is exactly one primitive.
+
+**Keep the first N runes** — masks everything after a fixed prefix.
 
 ```go
-package main
+_ = mask.Register("employee_id", mask.KeepFirstNFunc(9))
+// mask.Apply("employee_id", "EMP-ACME-12345") → "EMP-ACME-*****"
+```
 
-import (
-	"fmt"
-	"log"
+**Keep the last N runes** — masks everything before a fixed suffix.
 
-	"github.com/axonops/mask"
-)
+```go
+_ = mask.Register("internal_ref", mask.KeepLastNFunc(4))
+// mask.Apply("internal_ref", "REF-2025-001234") → "***********1234"
+```
 
-func init() {
-	// Mask an internal employee ID like "EMP-ACME-12345" by
-	// preserving the tenant prefix and masking the numeric tail.
-	// KeepFirstN gives us "keep the first N runes, mask the rest
-	// with the default mask character".
-	if err := mask.Register("employee_id", mask.KeepFirstNFunc(9)); err != nil {
-		// ErrDuplicateRule or ErrInvalidRule — fatal at init time.
-		log.Fatalf("register employee_id: %v", err)
-	}
+**Keep first and last N runes** — masks the middle, typical for account numbers or long identifiers.
+
+```go
+_ = mask.Register("warehouse_id", mask.KeepFirstLastFunc(3, 3))
+// mask.Apply("warehouse_id", "WH-NORTH-DOCK-9876") → "WH-************876"
+```
+
+**Regex-based masking** — replace every match of a pattern with a fixed string. Useful when the secret has a predictable shape surrounded by context bytes you want to keep, or when you want a one-off rule without walking the string yourself.
+
+```go
+// Redact any 6-or-more-digit run embedded in free text.
+r, err := mask.ReplaceRegexFunc(`\d{6,}`, "[REDACTED]")
+if err != nil {
+	log.Fatalf("compile regex: %v", err)
 }
+_ = mask.Register("free_text_digits", r)
 
-func main() {
-	fmt.Println(mask.Apply("employee_id", "EMP-ACME-12345"))
-	// Output: EMP-ACME-*****
+// mask.Apply("free_text_digits", "Order #1234567 shipped")
+//   → "Order #[REDACTED] shipped"
+```
+
+`ReplaceRegexFunc` returns `(nil, err)` on an invalid pattern — compile it once at init and panic fatally if it's wrong.
+
+Other factories in the same shape: `TruncateVisibleFunc(n)`, `PreserveDelimitersFunc(delim)`, `ReducePrecisionFunc(decimals)`, `FixedReplacementFunc(s)`, `DeterministicHashFunc(opts...)`.
+
+### 2. Compose a primitive via a closure
+
+Reach for a closure when you want to pre-process the input (trim whitespace, normalise case, split on a delimiter, etc.) before delegating to a primitive. Direct-call helpers (`KeepFirstN`, `KeepLastN`, `KeepFirstLast`, `SameLengthMask`, `PreserveDelimiters`, …) take an explicit mask rune, so a closure is the place to read your chosen character.
+
+```go
+func init() {
+	// internal_ticket: "ACME-TICKET-000123" → "ACME-TICKET-****23"
+	_ = mask.Register("internal_ticket", func(v string) string {
+		// Hyphens structure the ID; preserve them and keep the last 2
+		// non-separator runes.
+		return mask.PreserveDelimiters(mask.KeepLastN(v, 2, '*'), "-", '*')
+	})
 }
 ```
 
-Register rules during program initialisation only — see [Thread safety](#thread-safety). For multi-tenant services with different rule sets, construct one `Masker` per tenant via `mask.New()` and call `m.Register(...)` on each to keep their registries isolated.
+### 3. Honour per-instance mask-character config
 
-> **Factory vs. closure for the mask character.** Factories like `KeepFirstNFunc` capture `DefaultMaskChar` at construction and ignore later `SetMaskChar` / `WithMaskChar` overrides. If the rule must react to the configured character, register a closure that reads `m.MaskChar()` (or `mask.DefaultMaskChar` for the package-level registry) at call time instead.
+Factories capture `DefaultMaskChar` at construction. If you want your custom rule to react to a later `SetMaskChar` call or a `WithMaskChar` on a specific `Masker`, register a closure that reads `m.MaskChar()` at apply time:
+
+```go
+m := mask.New(mask.WithMaskChar('#'))
+_ = m.Register("employee_id", func(v string) string {
+	return mask.KeepFirstN(v, 9, m.MaskChar())
+})
+
+// m.Apply("employee_id", "EMP-ACME-12345") → "EMP-ACME-#####"
+```
+
+The package-level `mask.MaskChar()` gives the same access for rules registered on the global registry.
+
+### 4. Deterministic hashing with salt and version
+
+For pseudonymisation — stable but opaque identifiers — register `DeterministicHashFunc` with a salt and a version. Both are required; see the [Deterministic hashing](#deterministic-hashing-salt-and-version) section below for the full policy.
+
+```go
+func init() {
+	_ = mask.Register("user_id", mask.DeterministicHashFunc(
+		mask.WithSalt(os.Getenv("MASK_SALT")),
+		mask.WithSaltVersion("v1"),
+	))
+}
+
+// mask.Apply("user_id", "alice@example.com") → "sha256:v1:<hex16>"
+```
+
+### 5. A fully custom `RuleFunc`
+
+When the primitives don't compose cleanly — for example, a format with a rotating checksum, a bank-specific account-number grammar, or a content-aware rule — implement the masking from scratch. The function MUST be deterministic, MUST NOT panic, and MUST NOT return the original value on malformed input:
+
+```go
+// internal_token: keeps the last 4 hex characters, masks the rest,
+// and fails closed to a same-length mask on anything that is not a
+// pure hex string.
+func maskInternalToken(v string) string {
+	for _, r := range v {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return mask.SameLengthMask(v, '*') // fail closed on non-hex
+		}
+	}
+	return mask.KeepLastN(v, 4, '*')
+}
+
+func init() {
+	_ = mask.Register("internal_token", maskInternalToken)
+}
+
+// mask.Apply("internal_token", "deadbeefcafe1234")  → "************1234"
+// mask.Apply("internal_token", "nothex!!")          → "********"   (fail closed)
+// mask.Apply("internal_token", "")                  → ""
+```
+
+### Scoping: package-level vs per-instance
+
+`mask.Register` mutates the process-wide registry. That's the right choice for a service with a single rule set. Multi-tenant services — or tests that need rule-set isolation — construct one `Masker` per tenant:
+
+```go
+tenantA := mask.New()
+_ = tenantA.Register("employee_id", mask.KeepFirstNFunc(9))
+
+tenantB := mask.New()
+_ = tenantB.Register("employee_id", mask.KeepLastNFunc(4)) // different shape
+
+// tenantA.Apply("employee_id", "EMP-ACME-12345") → "EMP-ACME-*****"
+// tenantB.Apply("employee_id", "EMP-ACME-12345") → "**********2345"
+```
+
+Register rules during program initialisation only — see [Thread safety](#thread-safety).
+
+> **Factory vs. closure for the mask character.** Factories like `KeepFirstNFunc` capture `DefaultMaskChar` at construction and ignore later `SetMaskChar` / `WithMaskChar` overrides. If the rule must react to the configured character, use the closure pattern from §3 instead of the factory.
+
+### Compile-time safety
+
+Every built-in rule has an exported string constant of the form `mask.RuleX` — `mask.RuleEmailAddress`, `mask.RulePaymentCardPAN`, `mask.RuleUSSSN`, and so on. A call using a constant becomes a compile error on typo:
+
+```go
+// Safe — typo is caught by the compiler.
+masked := mask.Apply(mask.RuleEmailAddress, "alice@example.com")
+
+// Works today but a typo ("emial_address") silently falls back to [REDACTED]
+// because the rule is unknown.
+masked = mask.Apply("email_address", "alice@example.com")
+```
+
+Both forms are supported. The library's own tests and examples use string literals for brevity in documentation; production call sites benefit from the typed form.
 
 ## Configuration
 
@@ -305,14 +424,15 @@ Built-in rules read the configured character at apply time, so changes are picke
 
 ### Deterministic hashing (salt and version)
 
-`deterministic_hash` is registered by default with no salt. For production pseudonymisation you MUST configure a salt AND a salt version using `WithSalt`:
+`deterministic_hash` is registered by default with no salt. For production pseudonymisation you MUST configure both a salt (`WithSalt`) AND a salt version (`WithSaltVersion`):
 
 ```go
 m := mask.New()
 _ = m.Register(
 	"user_id",
 	mask.DeterministicHashFunc(
-		mask.WithSalt("your-secret-salt", "v1"),
+		mask.WithSalt("your-secret-salt"),
+		mask.WithSaltVersion("v1"),
 	),
 )
 ```
@@ -326,6 +446,8 @@ The output format is `<algo>:<version>:<hex16>` when a salt is configured, and `
 - Call `Register` during program initialisation, before any goroutine starts calling `Apply`.
 - Once every Register call has returned, the registry is read-only and `Apply` is safe for concurrent use by any number of goroutines.
 - Built-in rules are stateless pure functions. Custom `RuleFunc` implementations MUST satisfy the same contract.
+
+Violating this contract is a data race and will be reported by the Go race detector (`go test -race`). The library does NOT `defer recover()` around custom `RuleFunc` calls — a panic in a custom rule propagates out of `Apply`, by design. Custom rules MUST NOT panic; treat a panic as a programmer error and fix it at source.
 
 ```go
 // Correct — register once at init time.
@@ -346,7 +468,7 @@ Masking is one control in a broader compliance strategy — it is not a substitu
 |---|---|---|
 | PCI DSS display modes for PAN | Yes | `payment_card_pan`, `payment_card_pan_first6`, `payment_card_pan_last4` match the three common display modes. `payment_card_cvv` is same-length — CVV is Sensitive Authentication Data that MUST NOT be retained post-authorisation. |
 | HIPAA Safe Harbor de-identification | No | Identifier rules (including `medical_record_number`, `health_plan_beneficiary_id`) are pseudonymisation, not de-identification. Retained trailing digits combined with a date or ZIP remain re-identifiable. Register `full_redact` under the same rule name if you need Safe Harbor. |
-| GDPR pseudonymisation (Art. 4(5)) | Yes, with configured salt | `deterministic_hash` with `WithSalt(salt, version)` meets the GDPR definition. Salt management, rotation, and additional access controls are the operator's responsibility. |
+| GDPR pseudonymisation (Art. 4(5)) | Yes, with configured salt | `deterministic_hash` with `WithSalt(salt)` + `WithSaltVersion(version)` meets the GDPR definition. Salt management, rotation, and additional access controls are the operator's responsibility. |
 | GDPR anonymisation | No | No rule in this library is anonymisation — all preserved-window rules leak structure, and `deterministic_hash` is reversible given the input space. |
 
 ## Fallback behaviour

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The `mask` library is currently in pre-release (`v0.x`). Only the most recent `v0.x` minor release receives security fixes until `v1.0.0` stabilises the API.
+The `mask` library follows a `v0.x` versioning scheme. Only the most recent `v0.x` minor release receives security fixes until `v1.0.0` stabilises the API.
 
 | Version | Supported |
 |---------|-----------|
@@ -22,7 +22,9 @@ The `mask` library is currently in pre-release (`v0.x`). Only the most recent `v
 - Thread safety under the documented contract (`Register` at init, `Apply` concurrent thereafter).
 - Use of `crypto/sha256` for `deterministic_hash` — never MD5 or SHA-1.
 
-**Salt rotation and versioning.** The `deterministic_hash` primitive's `WithSalt(salt, version)` option requires both a salt and a version string. The version is emitted on the wire (`<algo>:<version>:<hex16>`) so downstream consumers can identify which salt generation a hash was computed with. Rotating the salt MUST coincide with changing the version — hashes computed with different versions are not comparable. A non-conforming version or a missing version with a non-empty salt is a fail-closed misconfiguration: every subsequent `Apply` returns `[REDACTED]` rather than producing a hash indistinguishable from the unsalted path. The salt itself is never logged, echoed in output, or exposed via `Describe`; the version, by design, is.
+**Salt rotation and versioning.** The `deterministic_hash` primitive takes its salt and version as independent options — `WithSalt(salt)` and `WithSaltVersion(version)` — both of which are required for keyed hashing. The version is emitted on the wire (`<algo>:<version>:<hex16>`) so downstream consumers can identify which salt generation a hash was computed with. Rotating the salt MUST coincide with changing the version — hashes computed with different versions are not comparable. A non-conforming version or a missing version paired with a non-empty salt is a fail-closed misconfiguration: every subsequent `Apply` returns `[REDACTED]` rather than producing a hash indistinguishable from the unsalted path. The salt itself is never logged, echoed in output, or exposed via `Describe`; the version, by design, is.
+
+**Unsalted default.** The built-in `deterministic_hash` rule is registered out of the box with no salt, so that `mask.Apply("deterministic_hash", v)` works in smoke tests without configuration. The unsalted path is NOT pseudonymisation for GDPR Art. 4(5) or HIPAA purposes and MUST NOT be used in production. Re-register the rule with `DeterministicHashFunc(WithSalt(...), WithSaltVersion(...))`, or register `full_redact` under the same name if hashing is not required. The default exists for ergonomics; production use requires an explicit configuration step.
 
 **Out of scope:**
 

--- a/doc.go
+++ b/doc.go
@@ -72,6 +72,27 @@
 // [SetMaskChar] or per instance with [WithMaskChar]. Built-in rules read the
 // configured character at apply time so changes are picked up immediately.
 //
+// # Deterministic hashing
+//
+// The deterministic_hash rule is registered by default with no salt. The
+// unsalted form is pseudonymisation for development and smoke tests only; it
+// is not suitable for GDPR Art. 4(5) pseudonymisation or any production use.
+// For production, re-register the rule with a configured salt and version:
+//
+//	m.Register("user_id",
+//	    mask.DeterministicHashFunc(
+//	        mask.WithSalt("your-secret-salt"),
+//	        mask.WithSaltVersion("v1"),
+//	    ))
+//
+// Both options are required for keyed hashing. The version MUST match
+// `^[A-Za-z0-9._-]{1,32}$`. A non-conforming version or a missing version
+// paired with a non-empty salt is a sticky misconfiguration: every
+// subsequent Apply on that rule returns [FullRedactMarker]. This
+// fail-closed policy prevents an operator who typoed the version from
+// silently producing hashes indistinguishable from the unsalted path.
+// See SECURITY.md for the full salt-rotation and versioning policy.
+//
 // # Non-goals
 //
 // The API does not accept [context.Context]. Masking is pure compute with no

--- a/docs/v0.9.0-requirements.md
+++ b/docs/v0.9.0-requirements.md
@@ -754,19 +754,20 @@ These are the composable building blocks. All domain rules above are thin wrappe
 Two optional parameters are exposed via functional options on the direct-call parametric variant and the factory:
 
 1. **Algorithm selection** — `WithAlgorithm(HashAlgorithm)` where `HashAlgorithm` is an enum with values `SHA256` (default), `SHA512`, `SHA3_256`, `SHA3_512`. The output prefix changes with the algorithm: `sha256:`, `sha512:`, `sha3-256:`, `sha3-512:`.
-2. **Salt and version** — `WithSalt(salt, version string)`. Both parameters are required when the caller wants keyed hashing. When a non-empty salt is supplied, the value is hashed as `HMAC(salt, value)` using the selected algorithm and the output is `<algo>:<version>:<first-16-hex>`. HMAC is chosen over concatenation because it is the standard primitive for keyed hashing and sidesteps length-extension concerns for SHA-2 family algorithms.
+2. **Salt and version** — `WithSalt(salt string)` and `WithSaltVersion(version string)`. Both options are required when the caller wants keyed hashing. When a non-empty salt is supplied, the value is hashed as `HMAC(salt, value)` using the selected algorithm and the output is `<algo>:<version>:<first-16-hex>`. HMAC is chosen over concatenation because it is the standard primitive for keyed hashing and sidesteps length-extension concerns for SHA-2 family algorithms.
 
    - **Version requirement.** The version string is emitted on the wire so a downstream consumer can identify which salt generation produced a given hash. Without a version, rotating the salt would silently invalidate every stored hash with no way to tell which hashes belong to which salt. The version is therefore mandatory alongside a non-empty salt.
    - **Version grammar.** `^[A-Za-z0-9._-]{1,32}$` — alphanumerics plus `.`, `-`, `_`, 1 to 32 bytes. Colons, whitespace, non-ASCII, and any other character are rejected.
-   - **Fail-closed on misconfiguration.** A non-empty salt paired with an empty or non-conforming version sets a sticky misconfiguration flag on the rule; every subsequent `Apply` returns `[REDACTED]`. This policy is deliberate: silent collapse to unsalted would produce hashes indistinguishable from the unsalted path, inverting the safety property. The flag cannot be cleared by a later option — `WithSalt("k", "bad"), WithSalt("k", "v1")` remains misconfigured.
-   - **Empty salt path.** `WithSalt("", anything)` is the unsalted path. The primitive emits `<algo>:<first-16-hex>` with no version; the version argument is ignored when no salt is in effect.
+   - **Fail-closed on misconfiguration.** A non-empty salt paired with an empty or non-conforming version sets a sticky misconfiguration flag on the rule; every subsequent `Apply` returns `[REDACTED]`. This policy is deliberate: silent collapse to unsalted would produce hashes indistinguishable from the unsalted path, inverting the safety property. Once set, the flag cannot be cleared by later options within the same factory call.
+   - **Empty salt path.** `WithSalt("")` is the unsalted path. The primitive emits `<algo>:<first-16-hex>` with no version; any `WithSaltVersion` option is ignored when no salt is in effect.
    - **Rotation.** The salt MUST remain constant for the lifetime of the process. If operators rotate the salt, they MUST change the version too. Downstream consumers comparing hashes across salt rotations should match on the (algorithm, version) tuple — hashes with different versions are not comparable even when the underlying value is identical.
 
 The built-in registered rule `deterministic_hash` continues to use SHA-256 with no salt (equivalent to `DeterministicHashFunc()` with zero options). Consumers who want a salted or alternative-algorithm variant register a named rule via the factory, e.g.:
 
 ```go
 m.Register("hashed_email", mask.DeterministicHashFunc(
-    mask.WithSalt(os.Getenv("MASK_SALT"), "v1"),
+    mask.WithSalt(os.Getenv("MASK_SALT")),
+    mask.WithSaltVersion("v1"),
     mask.WithAlgorithm(mask.SHA512),
 ))
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -30,6 +30,17 @@ func ExampleApply() {
 	// Output: a****@example.com
 }
 
+// ExampleApply_typedRuleName uses one of the exported rule-name
+// constants (`mask.RuleEmailAddress`) instead of a string literal.
+// The output is identical — but a typo such as `mask.RuleEmialAddress`
+// is a compile error rather than a silent fail-closed at runtime.
+// Prefer the typed form in production code; string literals stay
+// supported for scripts, tests, and documentation.
+func ExampleApply_typedRuleName() {
+	fmt.Println(mask.Apply(mask.RuleEmailAddress, "alice@example.com"))
+	// Output: a****@example.com
+}
+
 // ExampleApply_unknownRule demonstrates the fail-closed contract for
 // unknown rule names: Apply always returns [FullRedactMarker] rather than
 // the original value. This is the same behaviour consumers can rely on
@@ -123,14 +134,16 @@ func ExampleDescribe() {
 
 // ExampleApply_structuredLogRedaction shows a realistic use case: masking
 // several fields of a structured log line before writing it out. Each
-// field is routed to the rule that fits its semantic.
+// field is routed to the rule that fits its semantic. Production code
+// typically prefers the typed rule-name constants (mask.RuleX) so a
+// typo becomes a compile error.
 func ExampleApply_structuredLogRedaction() {
 	fields := []struct{ rule, value string }{
-		{"email_address", "alice@example.com"},
-		{"payment_card_pan", "4111-1111-1111-1111"},
-		{"us_ssn", "123-45-6789"},
-		{"ipv4_address", "192.168.1.42"},
-		{"jwt_token", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc"},
+		{mask.RuleEmailAddress, "alice@example.com"},
+		{mask.RulePaymentCardPAN, "4111-1111-1111-1111"},
+		{mask.RuleUSSSN, "123-45-6789"},
+		{mask.RuleIPv4Address, "192.168.1.42"},
+		{mask.RuleJWTToken, "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc"},
 	}
 
 	out := make([]string, 0, len(fields))

--- a/hash.go
+++ b/hash.go
@@ -103,12 +103,35 @@ type hashConfig struct {
 	algo          HashAlgorithm
 	salt          string // empty string means "no salt" — see WithSalt godoc
 	version       string // salt version; required iff salt != ""
+	saltSet       bool   // true once WithSalt has been applied at least once
+	versionSet    bool   // true once WithSaltVersion has been applied at least once
 	misconfigured bool   // sticky; once true, hashApply emits FullRedactMarker
 }
 
+// reconcile runs after either [WithSalt] or [WithSaltVersion] has been
+// applied. It defers final validation until both halves have been set at
+// least once in this factory call, then checks consistency. Any violation
+// after both are set flags the sticky misconfigured state: the salt and
+// version are cleared and every subsequent Apply emits [FullRedactMarker]
+// until a fresh factory call rebuilds the config.
+func (c *hashConfig) reconcile() {
+	if !c.saltSet || !c.versionSet {
+		return
+	}
+	if c.salt == "" {
+		// Unsalted path — orphan version is ignored in the output.
+		return
+	}
+	if !saltVersionPattern.MatchString(c.version) {
+		c.misconfigured = true
+		c.salt = ""
+		c.version = ""
+	}
+}
+
 // HashOption configures the deterministic-hash primitives. Use with
-// [DeterministicHashWith] and [DeterministicHashFunc]. Options apply in
-// supplied order, last-wins for repeated options.
+// [DeterministicHashFunc]. Options apply in supplied order, last-wins for
+// repeated options.
 type HashOption func(*hashConfig)
 
 // WithAlgorithm selects the hash algorithm. Values outside the four
@@ -123,6 +146,11 @@ type HashOption func(*hashConfig)
 //   - SHA3_512 → "sha3-512"
 //
 // MD5 and SHA-1 are explicitly unsupported.
+//
+// Example:
+//
+//	h := mask.DeterministicHashFunc(mask.WithAlgorithm(mask.SHA512))
+//	h("alice@example.com") // → "sha512:<hex16>"
 func WithAlgorithm(a HashAlgorithm) HashOption {
 	if a < 0 || a >= maxHashAlgorithm {
 		a = SHA256
@@ -132,67 +160,85 @@ func WithAlgorithm(a HashAlgorithm) HashOption {
 	}
 }
 
-// WithSalt enables keyed hashing via HMAC. Both salt and version are
-// required when the caller wants keyed hashing — the version is emitted on
-// the on-the-wire output so a downstream consumer can identify which salt
-// generation produced a given hash.
+// WithSalt sets the HMAC salt for keyed hashing. Combine with
+// [WithSaltVersion] to enable keyed output: a salted hash without
+// a configured version (or with a version that violates the
+// version grammar) is a misconfiguration and fails closed on every
+// subsequent Apply — see the package documentation for the full
+// policy.
 //
-// Output shape when a salt is configured:
+// WithSalt("") is the unsalted path — the primitive emits
+// `<algo>:<first-16-hex>` with no version segment.
 //
-//	<algo>:<version>:<first-16-hex>
+// The salt itself is never logged, echoed in output, returned in
+// error messages, or exposed via [Describe].
 //
-// For example, `DeterministicHashFunc(WithSalt("k", "v1"))` applied to
-// "alice@example.com" emits `sha256:v1:<hex16>` where <hex16> is the first
-// 16 hex chars of HMAC-SHA256("k", "alice@example.com").
+// Operational note: salt values live in in-memory Go strings and
+// may appear in process core dumps or goroutine stacks. Protect
+// the process, not the library.
 //
-// Version grammar: the version MUST match `^[A-Za-z0-9._-]{1,32}$`. Colons,
-// whitespace, non-ASCII characters, other punctuation, and versions longer
-// than 32 bytes are rejected. A misconfigured WithSalt call — empty
-// version or a version that violates the grammar — sets a sticky flag on
-// the hashConfig, and every subsequent Apply emits [FullRedactMarker].
-// This fail-closed policy prevents an operator who typoed the version
-// from silently producing hashes indistinguishable from the unsalted
-// path.
+// Example:
 //
-// WithSalt("", anything) is the unsalted path: the primitive emits
-// `<algo>:<first-16-hex>` with no version. The version is ignored when no
-// salt is in effect.
-//
-// Salt-rotation identification: if the operator changes the salt in their
-// process, the version MUST change too. Downstream consumers comparing
-// hashes across salt rotations should match on the (algorithm, version)
-// tuple — hashes with different versions are not comparable even when the
-// underlying value is identical.
-//
-// The salt itself is never logged, echoed in output, returned in error
-// messages, or exposed via [Describe]. The version, by contrast, is
-// emitted on the wire by design.
-//
-// Operational note: salt and version both live in in-memory Go strings
-// and may appear in process core dumps or goroutine stacks. Protect the
-// process, not the library.
-func WithSalt(salt, version string) HashOption {
+//	h := mask.DeterministicHashFunc(
+//	    mask.WithSalt("my-secret-salt"),
+//	    mask.WithSaltVersion("v1"),
+//	)
+//	h("alice@example.com") // → "sha256:v1:<hex16>"
+func WithSalt(salt string) HashOption {
 	return func(c *hashConfig) {
 		if c.misconfigured {
 			return // sticky; later options cannot clear a prior misconfiguration
 		}
-		if salt == "" {
-			// Empty salt is the unsalted path. Version is irrelevant.
-			c.salt = ""
-			c.version = ""
-			return
-		}
-		if !saltVersionPattern.MatchString(version) {
-			// Non-conforming or empty version with a non-empty salt is a
-			// misconfiguration. Set the sticky flag and clear any previously
-			// applied salt/version so no partial state leaks into hashApply.
-			c.misconfigured = true
-			c.salt = ""
-			c.version = ""
-			return
-		}
 		c.salt = salt
+		c.saltSet = true
+		c.reconcile()
+	}
+}
+
+// WithSaltVersion sets the salt-version identifier emitted on the
+// wire alongside the hash so downstream consumers can identify
+// which salt generation produced a given hash. Combine with
+// [WithSalt] to enable keyed hashing.
+//
+// Output shape when both salt and version are configured:
+//
+//	<algo>:<version>:<first-16-hex>
+//
+// For example, `DeterministicHashFunc(WithSalt("k"), WithSaltVersion("v1"))`
+// applied to "alice@example.com" emits `sha256:v1:<hex16>` where
+// <hex16> is the first 16 hex chars of HMAC-SHA256("k", "alice@example.com").
+//
+// Version grammar: the version MUST match `^[A-Za-z0-9._-]{1,32}$`.
+// Colons, whitespace, non-ASCII characters, other punctuation, and
+// versions longer than 32 bytes are rejected. A misconfiguration
+// (salt set without a conforming version, or a version set without
+// a salt) sets a sticky flag on the hashConfig and every
+// subsequent Apply emits [FullRedactMarker]. This fail-closed
+// policy prevents an operator who typoed the version from
+// silently producing hashes indistinguishable from the unsalted
+// path.
+//
+// Salt-rotation identification: if the operator changes the salt
+// in their process, the version MUST change too. Downstream
+// consumers comparing hashes across salt rotations should match on
+// the (algorithm, version) tuple — hashes with different versions
+// are not comparable even when the underlying value is identical.
+//
+// Example:
+//
+//	h := mask.DeterministicHashFunc(
+//	    mask.WithSalt("my-secret-salt"),
+//	    mask.WithSaltVersion("v1"),
+//	)
+//	h("alice@example.com") // → "sha256:v1:<hex16>"
+func WithSaltVersion(version string) HashOption {
+	return func(c *hashConfig) {
+		if c.misconfigured {
+			return
+		}
 		c.version = version
+		c.versionSet = true
+		c.reconcile()
 	}
 }
 
@@ -288,13 +334,23 @@ func hashApply(cfg hashConfig, v string) string {
 	return string(dst)
 }
 
-// buildConfig applies opts to a fresh hashConfig and returns it. Extracted
-// so DeterministicHashWith and DeterministicHashFunc construct config with
-// byte-identical semantics.
+// buildConfig applies opts to a fresh hashConfig and finalises the
+// consistency check between salt and version. Options set salt and
+// version independently so they can appear in any order; the final
+// validate call after all options have been applied is what sets the
+// sticky misconfigured flag if the combination is inconsistent.
 func buildConfig(opts []HashOption) hashConfig {
 	var cfg hashConfig
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	// Final guard: a salt configured without ever pairing it with a
+	// version is also a misconfiguration. reconcile() defers until
+	// both halves are seen, so this case needs a terminal check.
+	if !cfg.misconfigured && cfg.saltSet && cfg.salt != "" && !cfg.versionSet {
+		cfg.misconfigured = true
+		cfg.salt = ""
+		cfg.version = ""
 	}
 	return cfg
 }
@@ -316,27 +372,17 @@ func buildConfig(opts []HashOption) hashConfig {
 // produce different outputs. Callers handling multilingual data should
 // normalise before hashing.
 //
-// For a keyed variant or a different algorithm, use [DeterministicHashWith]
-// or build a [RuleFunc] via [DeterministicHashFunc].
+// For a keyed variant or a different algorithm, build a [RuleFunc] via
+// [DeterministicHashFunc] and invoke it:
 //
-// Example: DeterministicHash("alice@example.com") → "sha256:559aead08264d592".
+//	h := mask.DeterministicHashFunc(
+//	    mask.WithSalt("secret"),
+//	    mask.WithSaltVersion("v1"),
+//	)("alice@example.com")
+//
+// Example: DeterministicHash("alice@example.com") → "sha256:ff8d9819fc0e12bf".
 func DeterministicHash(v string) string {
 	return hashApply(hashConfig{algo: SHA256}, v)
-}
-
-// DeterministicHashWith is the parametric direct-call variant of
-// [DeterministicHash]. Options apply in supplied order, last-wins.
-//
-// This helper is for one-off ad-hoc use. Hot paths should construct a
-// [RuleFunc] once via [DeterministicHashFunc] and reuse it — a `...HashOption`
-// variadic is allocated on every call here.
-//
-// Example:
-//
-//	h := mask.DeterministicHashWith("alice", mask.WithAlgorithm(mask.SHA512))
-//	// h == "sha512:..."
-func DeterministicHashWith(v string, opts ...HashOption) string {
-	return hashApply(buildConfig(opts), v)
 }
 
 // DeterministicHashFunc builds a [RuleFunc] that hashes its input according
@@ -351,7 +397,8 @@ func DeterministicHashWith(v string, opts ...HashOption) string {
 // Example:
 //
 //	_ = m.Register("hashed_email", mask.DeterministicHashFunc(
-//	    mask.WithSalt(os.Getenv("MASK_SALT"), "v1"),
+//	    mask.WithSalt(os.Getenv("MASK_SALT")),
+//	    mask.WithSaltVersion("v1"),
 //	    mask.WithAlgorithm(mask.SHA3_256),
 //	))
 func DeterministicHashFunc(opts ...HashOption) RuleFunc {

--- a/internal_coverage_test.go
+++ b/internal_coverage_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Internal tests that exercise defensive branches the black-box
+// `package mask_test` suite cannot reach because they sit behind
+// earlier guards. The goal is to pin the fallback behaviour so a
+// future refactor cannot silently delete the branch.
+
+// TestInternal_KeepFirstLastNonSep_DefensiveBranches covers the
+// empty-input and window-too-big branches of the shared helper
+// which the financial / identity callers never trigger because
+// they pre-filter before calling.
+func TestInternal_KeepFirstLastNonSep_DefensiveBranches(t *testing.T) {
+	t.Parallel()
+	noSep := func(rune) bool { return false }
+	assert.Equal(t, "", keepFirstLastNonSep("", 2, 2, '*', noSep),
+		"empty input must return empty")
+	assert.Equal(t, "****", keepFirstLastNonSep("abcd", 2, 2, '*', noSep),
+		"window exactly equal to non-separator count must fall back to same-length mask")
+}
+
+// TestInternal_ClampNonNeg_Negative pins the negative-input branch.
+func TestInternal_ClampNonNeg_Negative(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, clampNonNeg(-1), "negative clamps to zero")
+	assert.Equal(t, 0, clampNonNeg(-100), "large-negative clamps to zero")
+	assert.Equal(t, 5, clampNonNeg(5), "positive passes through")
+}
+
+// TestInternal_HashSumUnsalted_DefaultBranch exercises the safety
+// fallback when an out-of-range HashAlgorithm is passed directly.
+// In normal use callers route through resolveAlgo, which clamps.
+func TestInternal_HashSumUnsalted_DefaultBranch(t *testing.T) {
+	t.Parallel()
+	// -1 is not in the known-algorithm range; the helper MUST fall
+	// back to SHA-256 rather than panic.
+	out := hashSumUnsalted(HashAlgorithm(-1), "x")
+	assert.Len(t, out, 32, "fallback must produce a 32-byte SHA-256 digest")
+}
+
+// TestInternal_ResolveAlgo_OutOfRange pins the resolveAlgo clamp
+// for values below zero and at-or-above the maximum.
+func TestInternal_ResolveAlgo_OutOfRange(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, SHA256, resolveAlgo(HashAlgorithm(-1)))
+	assert.Equal(t, SHA256, resolveAlgo(maxHashAlgorithm))
+	assert.Equal(t, SHA256, resolveAlgo(maxHashAlgorithm+1))
+	assert.Equal(t, SHA256, resolveAlgo(SHA256))
+	assert.Equal(t, SHA512, resolveAlgo(SHA512))
+}
+
+// TestInternal_Masker_ZeroValueLoadRules confirms that a zero-value
+// Masker initialises on first access. Public callers normally use
+// [New], but the type is exported so zero-value use is permitted.
+func TestInternal_Masker_ZeroValueLoadRules(t *testing.T) {
+	t.Parallel()
+	var m Masker
+	// Direct call to loadRules exercises the rm == nil branch.
+	rm := m.loadRules()
+	require.NotNil(t, rm, "zero-value Masker must lazily initialise")
+	// Subsequent calls skip the initialisation branch.
+	rm2 := m.loadRules()
+	assert.Same(t, rm, rm2, "second call returns the same map pointer")
+}
+
+// TestInternal_MustRegisterBuiltin_PanicOnDuplicate covers the
+// defensive panic when a duplicate name is registered at init
+// time. The built-in registrar set cannot trigger this, so we
+// test it directly on a fresh Masker.
+func TestInternal_MustRegisterBuiltin_PanicOnDuplicate(t *testing.T) {
+	t.Parallel()
+	var m Masker
+	m.ensureInit()
+	// The name below is guaranteed not to collide with built-ins.
+	const name = "internal_test_duplicate_rule"
+	m.mustRegisterBuiltin(name, func(v string) string { return v }, RuleInfo{Name: name, Category: "test"})
+	assert.PanicsWithValue(t,
+		"mask: built-in registration failed: mask: rule already registered: name \""+name+"\"",
+		func() {
+			m.mustRegisterBuiltin(name, func(v string) string { return v }, RuleInfo{Name: name, Category: "test"})
+		},
+		"second registration with the same name MUST panic",
+	)
+}
+
+// TestInternal_IsLDHLabel_EmptyAndInvalid covers the empty-string
+// branch and each rejection path of the label validator that the
+// hostname rule's own tests don't enumerate directly.
+func TestInternal_IsLDHLabel_EmptyAndInvalid(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isLDHLabel(""), "empty label is invalid")
+	assert.False(t, isLDHLabel("foo bar"), "space is invalid")
+	assert.False(t, isLDHLabel("foo.bar"), "dot is invalid inside a single label")
+	assert.False(t, isLDHLabel("foo\x00bar"), "NUL is invalid")
+	assert.True(t, isLDHLabel("foo-bar_baz-42"), "LDH with underscore and digit is valid")
+}
+
+// TestInternal_IsBracketedIPv6Host_Malformed covers the branches
+// of the IPv6 bracket validator that the public URL tests exercise
+// only tangentially.
+func TestInternal_IsBracketedIPv6Host_Malformed(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isBracketedIPv6Host("no-bracket"), "missing leading bracket is invalid")
+	assert.False(t, isBracketedIPv6Host("[2001:db8::1"), "missing closing bracket is invalid")
+	assert.False(t, isBracketedIPv6Host("[[2001:db8::1]"), "double opening bracket is invalid")
+	assert.False(t, isBracketedIPv6Host("[2001:db8::1]abc"), "trailing non-colon is invalid")
+	assert.True(t, isBracketedIPv6Host("[2001:db8::1]"), "canonical bracketed IPv6 is valid")
+	assert.True(t, isBracketedIPv6Host("[2001:db8::1]:8080"), "bracketed IPv6 with port is valid")
+}
+
+// TestInternal_IsBase64URLSeg_EmptyAndInvalid covers the empty and
+// disallowed-character branches.
+func TestInternal_IsBase64URLSeg_EmptyAndInvalid(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isBase64URLSeg(""), "empty segment rejected")
+	assert.False(t, isBase64URLSeg("has+plus"), "`+` is base64 standard, not base64url")
+	assert.False(t, isBase64URLSeg("has/slash"), "`/` is base64 standard, not base64url")
+	assert.False(t, isBase64URLSeg("has=padding"), "`=` padding not accepted")
+	assert.True(t, isBase64URLSeg("Abc123_-"), "canonical base64url accepted")
+}
+
+// TestInternal_IsPlainDecimal_EdgeCases covers sign-only, multi-dot,
+// leading-sign-only, and NaN-like inputs.
+func TestInternal_IsPlainDecimal_EdgeCases(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isPlainDecimal(""))
+	assert.False(t, isPlainDecimal("+"), "sign with no digits")
+	assert.False(t, isPlainDecimal("-"), "sign with no digits")
+	assert.False(t, isPlainDecimal("1.2.3"), "multiple dots")
+	assert.False(t, isPlainDecimal("1e5"), "scientific rejected")
+	assert.False(t, isPlainDecimal("."), "dot only")
+	assert.True(t, isPlainDecimal("0"))
+	assert.True(t, isPlainDecimal("42"))
+	assert.True(t, isPlainDecimal("-42.5"))
+	assert.True(t, isPlainDecimal("+0.0"))
+}
+
+// TestInternal_AllASCIIDigits_EmptyString covers the short-circuit
+// that the public country / telecom rules never reach (empty input
+// is filtered earlier in each rule's body).
+func TestInternal_AllASCIIDigits_EmptyString(t *testing.T) {
+	t.Parallel()
+	assert.False(t, allASCIIDigits(""), "empty string is not all digits")
+	assert.True(t, allASCIIDigits("0123456789"))
+	assert.False(t, allASCIIDigits("012a456"))
+}
+
+// TestInternal_IsUKOutwardCode_EdgeCases covers the length and
+// character-class rejection branches.
+func TestInternal_IsUKOutwardCode_EdgeCases(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isUKOutwardCode("A"), "1-byte too short")
+	assert.False(t, isUKOutwardCode("ABCDE"), "5-byte too long")
+	assert.False(t, isUKOutwardCode("1B"), "leading byte must be letter")
+	assert.False(t, isUKOutwardCode("AB"), "outward code with no digit is rejected")
+	assert.False(t, isUKOutwardCode("A!"), "non-LDH byte rejected")
+	assert.True(t, isUKOutwardCode("M1"))
+	assert.True(t, isUKOutwardCode("SW1A"))
+}
+
+// TestInternal_IsUKInwardCode_EdgeCases covers the shape-mismatch
+// rejections.
+func TestInternal_IsUKInwardCode_EdgeCases(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isUKInwardCode(""))
+	assert.False(t, isUKInwardCode("1AB"[:2]), "wrong length")
+	assert.False(t, isUKInwardCode("ABC"), "first byte must be digit")
+	assert.False(t, isUKInwardCode("12A"), "second byte must be letter")
+	assert.True(t, isUKInwardCode("1AB"))
+}
+
+// TestInternal_IsGeoMaskable_EdgeCases covers the leading-plus
+// rejection and the no-dot branch.
+func TestInternal_IsGeoMaskable_EdgeCases(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isGeoMaskable(""))
+	assert.False(t, isGeoMaskable("+1.23"), "leading plus rejected for geo rules")
+	assert.False(t, isGeoMaskable("123"), "integer rejected — no fractional part to mask")
+	assert.False(t, isGeoMaskable("1.2"), "fractional too short to mask")
+	assert.False(t, isGeoMaskable("1..2"), "double-dot rejected")
+	assert.False(t, isGeoMaskable("abc"), "non-decimal rejected")
+	assert.True(t, isGeoMaskable("1.234"))
+	assert.True(t, isGeoMaskable("-122.4194155"))
+}
+
+// TestInternal_MonthNameRecognised_Boundaries pins the rejection
+// branches that the public DOB tests exercise only partially.
+func TestInternal_MonthNameRecognised_Boundaries(t *testing.T) {
+	t.Parallel()
+	assert.False(t, monthNameRecognised(""))
+	assert.False(t, monthNameRecognised(strings.Repeat("x", 20)), "length > longest month name rejected")
+	assert.False(t, monthNameRecognised("Xanuary"), "wrong letter rejected")
+	assert.True(t, monthNameRecognised("January"))
+	assert.True(t, monthNameRecognised("DECEMBER"), "upper-case accepted")
+	assert.True(t, monthNameRecognised("May"))
+}

--- a/mask.go
+++ b/mask.go
@@ -60,14 +60,23 @@ type RuleFunc func(value string) string
 type RuleInfo struct {
 	// Name is the canonical label the rule is registered under.
 	Name string
-	// Category is one of: identity, financial, health, technology, telecom,
-	// location, country, or utility. May be empty for user-registered rules.
+	// Category groups related rules. Built-in rules use one of:
+	// "identity" (including country-specific identity rules),
+	// "financial", "health", "technology", "telecom", "location", or
+	// "utility". The field is a free-form string — future rules may
+	// introduce additional categories — and is empty for user-registered
+	// rules that omit it.
 	Category string
-	// Jurisdiction names the country or standard this rule applies to
-	// (for example "US", "UK", "global", "PCI DSS"). May be empty.
+	// Jurisdiction names the country or standard a rule applies to.
+	// Built-in rules use full names: "global", "global (HIPAA)",
+	// "global (PCI DSS)", "United States", "United Kingdom",
+	// "Canada", "India", "Brazil", "Mexico", "Spain", "South Africa",
+	// "China", "Singapore", "Australia". The field is free-form and
+	// may be empty for user-registered rules.
 	Jurisdiction string
 	// Description is a human-readable sentence explaining what the rule does.
-	// May be empty for user-registered rules.
+	// Built-in rules end their description with an "Example: input → output"
+	// line. May be empty for user-registered rules.
 	Description string
 }
 
@@ -82,6 +91,11 @@ type Option func(*Masker)
 // The value should be a printable Unicode code point. Negative values, the
 // zero rune, and unassigned code points are accepted by the setter but may
 // produce unreadable output; this library does not validate the choice.
+//
+// Example:
+//
+//	m := mask.New(mask.WithMaskChar('X'))
+//	m.Apply("us_ssn", "123-45-6789") // → "XXX-XX-6789"
 func WithMaskChar(c rune) Option {
 	return func(m *Masker) {
 		m.setMaskChar(c)
@@ -127,6 +141,11 @@ var builtinRegistrars []func(*Masker)
 // New creates a [Masker] with built-in rules pre-registered and applies the
 // supplied options. The returned Masker is isolated from the package-level
 // registry: rules registered on one Masker are invisible to any other.
+//
+// Example:
+//
+//	m := mask.New(mask.WithMaskChar('#'))
+//	m.Apply("email_address", "alice@example.com") // → "a####@example.com"
 func New(opts ...Option) *Masker {
 	m := &Masker{}
 	m.ensureInit()
@@ -178,6 +197,24 @@ func (m *Masker) maskChar() rune {
 	return m.maskCharAtomic.Load()
 }
 
+// MaskChar returns the mask rune currently configured on this Masker.
+// The returned value reflects the most recent [WithMaskChar] applied at
+// construction or [SetMaskChar] at runtime.
+//
+// Custom rule authors who want their rule to honour per-instance
+// mask-character configuration call this inside the registered closure:
+//
+//	m.Register("my_rule", func(v string) string {
+//	    return mask.KeepFirstN(v, 4, m.MaskChar())
+//	})
+//
+// Calling MaskChar on a zero-value Masker is safe; the returned rune is
+// [DefaultMaskChar] until [SetMaskChar] or [WithMaskChar] changes it.
+func (m *Masker) MaskChar() rune {
+	m.ensureInit()
+	return m.maskChar()
+}
+
 // Apply masks value using the named rule.
 //
 // If rule is not registered on this Masker, Apply returns [FullRedactMarker]
@@ -187,6 +224,8 @@ func (m *Masker) maskChar() rune {
 // Apply is safe for concurrent use by any number of goroutines provided all
 // [Masker.Register] calls have completed before the first Apply call. See the
 // thread-safety contract on [Masker].
+//
+// Example: m.Apply("email_address", "alice@example.com") → "a****@example.com".
 func (m *Masker) Apply(rule, value string) string {
 	// Fast path: once initialised the registry pointer is non-nil and reads
 	// are lock-free. The slow-path ensureInit call only fires on a Masker
@@ -218,6 +257,11 @@ func (m *Masker) Apply(rule, value string) string {
 //
 // Register MUST NOT be called concurrently with [Masker.Apply]. See the
 // thread-safety contract on [Masker].
+//
+// Example:
+//
+//	err := m.Register("my_token", mask.KeepFirstNFunc(4))
+//	// m.Apply("my_token", "SensitiveToken") → "Sens**********".
 func (m *Masker) Register(name string, fn RuleFunc) error {
 	m.ensureInit()
 	return m.registerLocked(name, fn, RuleInfo{Name: name})
@@ -276,6 +320,11 @@ func (m *Masker) loadRules() *ruleMap {
 
 // Rules returns the sorted list of rule names registered on this Masker.
 // The slice is freshly allocated; callers may mutate it freely.
+//
+// Example:
+//
+//	names := m.Rules()
+//	// names == ["api_key", "bank_account_number", ..., "uuid"] (sorted)
 func (m *Masker) Rules() []string {
 	rm := m.loadRules()
 	names := make([]string, 0, len(*rm))
@@ -289,6 +338,11 @@ func (m *Masker) Rules() []string {
 // HasRule reports whether a rule with the given name is registered on this
 // Masker. Use this to avoid triggering the [FullRedactMarker] fallback when a
 // rule's presence is uncertain.
+//
+// Example:
+//
+//	m.HasRule("email_address") // → true
+//	m.HasRule("not_a_rule")    // → false
 func (m *Masker) HasRule(name string) bool {
 	rm := m.loadRules()
 	_, ok := (*rm)[name]
@@ -299,6 +353,11 @@ func (m *Masker) HasRule(name string) bool {
 // indicating whether the rule was found. For rules registered via
 // [Masker.Register] the Name field is populated and the other fields may be
 // empty; built-in rules populate every field.
+//
+// Example:
+//
+//	info, ok := m.Describe("email_address")
+//	// info.Category == "identity", info.Jurisdiction == "global"
 func (m *Masker) Describe(name string) (RuleInfo, bool) {
 	rm := m.loadRules()
 	e, ok := (*rm)[name]
@@ -308,6 +367,32 @@ func (m *Masker) Describe(name string) (RuleInfo, bool) {
 	return e.info, true
 }
 
+// DescribeAll returns the [RuleInfo] for every rule registered on this
+// Masker, sorted by [RuleInfo.Name]. Useful for dashboards, audit tools,
+// and configuration UIs that enumerate the full catalogue in one pass.
+//
+// The returned slice is freshly allocated on every call — callers may
+// mutate it freely. Calling DescribeAll is equivalent to iterating
+// [Masker.Rules] and calling [Masker.Describe] for each name, but
+// avoids the redundant guard clause on the always-present lookup.
+//
+// Example:
+//
+//	for _, info := range m.DescribeAll() {
+//	    fmt.Printf("%s [%s] — %s\n", info.Name, info.Category, info.Description)
+//	}
+func (m *Masker) DescribeAll() []RuleInfo {
+	rm := m.loadRules()
+	infos := make([]RuleInfo, 0, len(*rm))
+	for _, e := range *rm {
+		infos = append(infos, e.info)
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].Name < infos[j].Name
+	})
+	return infos
+}
+
 // defaultMasker backs the package-level API. It is intentionally not
 // constructed via [New]; its initialisation is lazy so all package init
 // functions (including those that append to builtinRegistrars) run first.
@@ -315,12 +400,19 @@ var defaultMasker = &Masker{}
 
 // Apply masks value using the named rule from the package-level registry.
 // See [Masker.Apply] for semantics.
+//
+// Example: mask.Apply("email_address", "alice@example.com") → "a****@example.com".
 func Apply(rule, value string) string {
 	return defaultMasker.Apply(rule, value)
 }
 
 // Register adds a custom masking rule to the package-level registry.
 // See [Masker.Register] for the rule-name grammar and thread-safety contract.
+//
+// Example:
+//
+//	err := mask.Register("my_token", mask.KeepFirstNFunc(4))
+//	// mask.Apply("my_token", "SensitiveToken") → "Sens**********".
 func Register(name string, fn RuleFunc) error {
 	return defaultMasker.Register(name, fn)
 }
@@ -331,6 +423,11 @@ func Register(name string, fn RuleFunc) error {
 //
 // SetMaskChar MUST NOT be called concurrently with [Apply]. Per-instance
 // control is available via [WithMaskChar].
+//
+// Example:
+//
+//	mask.SetMaskChar('#')
+//	mask.Apply("us_ssn", "123-45-6789") // → "###-##-6789"
 func SetMaskChar(c rune) {
 	defaultMasker.setMaskChar(c)
 }
@@ -351,4 +448,16 @@ func HasRule(name string) bool {
 // registry. See [Masker.Describe].
 func Describe(name string) (RuleInfo, bool) {
 	return defaultMasker.Describe(name)
+}
+
+// DescribeAll returns the [RuleInfo] for every rule registered on the
+// package-level registry, sorted by name. See [Masker.DescribeAll].
+func DescribeAll() []RuleInfo {
+	return defaultMasker.DescribeAll()
+}
+
+// MaskChar returns the mask rune currently configured on the package-level
+// registry. See [Masker.MaskChar].
+func MaskChar() rune {
+	return defaultMasker.MaskChar()
 }

--- a/primitives.go
+++ b/primitives.go
@@ -17,6 +17,7 @@ package mask
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode/utf8"
 )
@@ -96,9 +97,17 @@ func SameLengthMask(v string, c rune) string {
 // rune count of v returns v unchanged.
 //
 // Example: KeepFirstN("Sensitive", 4, '*') → "Sens*****".
+//
+// Fails closed on invalid UTF-8 input: rather than echoing the raw
+// bytes (which would violate the library-wide "output is always
+// valid UTF-8" contract), the function routes such inputs through
+// [SameLengthMask].
 func KeepFirstN(v string, n int, c rune) string {
 	if v == "" {
 		return ""
+	}
+	if !utf8.ValidString(v) {
+		return SameLengthMask(v, c)
 	}
 	if n < 0 {
 		n = 0
@@ -123,9 +132,17 @@ func KeepFirstN(v string, n int, c rune) string {
 // the rune count of v returns v unchanged.
 //
 // Example: KeepLastN("Sensitive", 4, '*') → "*****tive".
+//
+// Fails closed on invalid UTF-8 input: rather than echoing the raw
+// bytes (which would violate the library-wide "output is always
+// valid UTF-8" contract), the function routes such inputs through
+// [SameLengthMask].
 func KeepLastN(v string, n int, c rune) string {
 	if v == "" {
 		return ""
+	}
+	if !utf8.ValidString(v) {
+		return SameLengthMask(v, c)
 	}
 	if n < 0 {
 		n = 0
@@ -152,9 +169,17 @@ func KeepLastN(v string, n int, c rune) string {
 // than the input.
 //
 // Example: KeepFirstLast("SensitiveData", 4, 4, '*') → "Sens*****Data".
+//
+// Fails closed on invalid UTF-8 input: rather than echoing the raw
+// bytes (which would violate the library-wide "output is always
+// valid UTF-8" contract), the function routes such inputs through
+// [SameLengthMask].
 func KeepFirstLast(v string, first, last int, c rune) string {
 	if v == "" {
 		return ""
+	}
+	if !utf8.ValidString(v) {
+		return SameLengthMask(v, c)
 	}
 	if first < 0 {
 		first = 0
@@ -227,22 +252,13 @@ func preserveDelimitersWithScan(v, delim string, c rune) string {
 	var b strings.Builder
 	b.Grow(len(v))
 	for _, r := range v {
-		if containsRune(delimRunes, r) {
+		if slices.Contains(delimRunes, r) {
 			b.WriteRune(r)
 		} else {
 			b.WriteRune(c)
 		}
 	}
 	return b.String()
-}
-
-func containsRune(rs []rune, needle rune) bool {
-	for _, r := range rs {
-		if r == needle {
-			return true
-		}
-	}
-	return false
 }
 
 // ReplaceRegex applies the regex pattern to v and replaces every match with
@@ -264,6 +280,11 @@ func ReplaceRegex(v, pattern, replacement string) (string, error) {
 // ReplaceRegexFunc compiles pattern once and returns a [RuleFunc] that
 // applies it on every call. An invalid pattern returns a wrapped error and a
 // nil [RuleFunc] — never panics.
+//
+// Example:
+//
+//	r, _ := mask.ReplaceRegexFunc(`\d{6,}`, "[REDACTED]")
+//	r("Order #1234567 shipped") // → "Order #[REDACTED] shipped"
 func ReplaceRegexFunc(pattern, replacement string) (RuleFunc, error) {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
@@ -276,6 +297,8 @@ func ReplaceRegexFunc(pattern, replacement string) (RuleFunc, error) {
 
 // TruncateVisibleFunc builds a [RuleFunc] that truncates its input to the
 // first n runes. See [TruncateVisible] for boundary behaviour.
+//
+// Example: TruncateVisibleFunc(4)("Sensitive") → "Sens".
 func TruncateVisibleFunc(n int) RuleFunc {
 	return func(v string) string {
 		return TruncateVisible(v, n)
@@ -336,6 +359,8 @@ func ReducePrecision(v string, decimals int, c rune) string {
 
 // ReducePrecisionFunc builds a [RuleFunc] that reduces decimal precision.
 // See [ReducePrecision] for semantics.
+//
+// Example: ReducePrecisionFunc(2)("37.7749") → "37.77**".
 func ReducePrecisionFunc(decimals int) RuleFunc {
 	return func(v string) string {
 		return ReducePrecision(v, decimals, DefaultMaskChar)
@@ -367,14 +392,16 @@ func writeReducePrecision(b *strings.Builder, v string, decimals int, c rune) {
 //
 // Mask-character note: factories capture [DefaultMaskChar] at construction
 // and ignore later per-Masker overrides configured via [WithMaskChar] or
-// [SetMaskChar]. A caller who needs the instance mask character should use
-// the direct-call helper inside a closure: for example
+// [SetMaskChar]. A caller who needs a specific mask character should
+// register a closure that captures the desired rune directly: for example
 //
-//	r := func(v string) string { return mask.KeepFirstN(v, 4, m.MaskChar()) }
+//	const myMaskChar = '#'
+//	fn := func(v string) string { return mask.KeepFirstN(v, 4, myMaskChar) }
 //
-// (where `m.MaskChar()` reads whatever state the caller tracks). The
-// factory's stability is deliberate: registered parametric rules should not
-// change output when a global knob is turned.
+// The factory's stability is deliberate: registered parametric rules should
+// not change output when a global knob is turned.
+//
+// Example: KeepFirstNFunc(4)("Sensitive") → "Sens*****".
 func KeepFirstNFunc(n int) RuleFunc {
 	return func(v string) string {
 		return KeepFirstN(v, n, DefaultMaskChar)
@@ -384,6 +411,8 @@ func KeepFirstNFunc(n int) RuleFunc {
 // KeepLastNFunc returns a [RuleFunc] that keeps the last n runes, masking
 // the rest with [DefaultMaskChar]. See [KeepLastN]. The same mask-character
 // capture semantics as [KeepFirstNFunc] apply.
+//
+// Example: KeepLastNFunc(4)("Sensitive") → "*****tive".
 func KeepLastNFunc(n int) RuleFunc {
 	return func(v string) string {
 		return KeepLastN(v, n, DefaultMaskChar)
@@ -393,6 +422,8 @@ func KeepLastNFunc(n int) RuleFunc {
 // KeepFirstLastFunc returns a [RuleFunc] that keeps the first and last runes
 // and masks the middle. See [KeepFirstLast]. The same mask-character capture
 // semantics as [KeepFirstNFunc] apply.
+//
+// Example: KeepFirstLastFunc(4, 4)("SensitiveData") → "Sens*****Data".
 func KeepFirstLastFunc(first, last int) RuleFunc {
 	return func(v string) string {
 		return KeepFirstLast(v, first, last, DefaultMaskChar)
@@ -403,6 +434,8 @@ func KeepFirstLastFunc(first, last int) RuleFunc {
 // [DefaultMaskChar] while preserving runes listed in delim. The delimiter
 // set is captured once at construction and reused on every call. The same
 // mask-character capture semantics as [KeepFirstNFunc] apply.
+//
+// Example: PreserveDelimitersFunc("-")("ab-cd") → "**-**".
 func PreserveDelimitersFunc(delim string) RuleFunc {
 	delimSet := make(map[rune]struct{}, len(delim))
 	for _, r := range delim {

--- a/primitives_bench_test.go
+++ b/primitives_bench_test.go
@@ -162,7 +162,7 @@ func BenchmarkDeterministicHash_1000(b *testing.B) {
 }
 
 func BenchmarkDeterministicHash_Salted_1000(b *testing.B) {
-	r := mask.DeterministicHashFunc(mask.WithSalt("secretkey", "v1"))
+	r := mask.DeterministicHashFunc(mask.WithSalt("secretkey"), mask.WithSaltVersion("v1"))
 	b.ReportAllocs()
 	b.ResetTimer()
 	var s string

--- a/primitives_test.go
+++ b/primitives_test.go
@@ -474,7 +474,7 @@ func TestDeterministicHash_WithAlgorithm(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := mask.DeterministicHashWith("alice@example.com", mask.WithAlgorithm(tc.algo))
+			out := mask.DeterministicHashFunc(mask.WithAlgorithm(tc.algo))("alice@example.com")
 			want := tc.prefix + ":"
 			assert.True(t, strings.HasPrefix(out, want), "got %q, want prefix %q", out, want)
 			assert.Equal(t, len(tc.prefix)+1+16, len(out))
@@ -502,7 +502,7 @@ func TestDeterministicHash_WithSalt_UsesHMAC(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mask.DeterministicHashWith(val, mask.WithAlgorithm(tc.algo), mask.WithSalt(salt, version))
+			got := mask.DeterministicHashFunc(mask.WithAlgorithm(tc.algo), mask.WithSalt(salt), mask.WithSaltVersion(version))(val)
 			h := hmac.New(tc.ctor, []byte(salt))
 			h.Write([]byte(val))
 			want := tc.prefix + ":" + version + ":" + hex.EncodeToString(h.Sum(nil)[:8])
@@ -511,9 +511,9 @@ func TestDeterministicHash_WithSalt_UsesHMAC(t *testing.T) {
 	}
 }
 
-func TestDeterministicHashWith_IncludesVersion(t *testing.T) {
+func TestDeterministicHashFunc_IncludesVersion(t *testing.T) {
 	t.Parallel()
-	out := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", "v1"))
+	out := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion("v1"))("alice@example.com")
 	// Must begin with the versioned prefix and be exactly 26 bytes long:
 	// "sha256:" (7) + "v1:" (3) + 16 hex = 26.
 	assert.True(t, strings.HasPrefix(out, "sha256:v1:"), "got %q", out)
@@ -522,7 +522,7 @@ func TestDeterministicHashWith_IncludesVersion(t *testing.T) {
 
 func TestDeterministicHash_WithSalt_IsDeterministic(t *testing.T) {
 	t.Parallel()
-	r := mask.DeterministicHashFunc(mask.WithSalt("k", "v1"))
+	r := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion("v1"))
 	first := r("alice@example.com")
 	for i := 0; i < 1000; i++ {
 		assert.Equal(t, first, r("alice@example.com"))
@@ -532,8 +532,8 @@ func TestDeterministicHash_WithSalt_IsDeterministic(t *testing.T) {
 func TestDeterministicHash_DifferentSalt_DifferentOutput(t *testing.T) {
 	t.Parallel()
 	const v = "alice@example.com"
-	a := mask.DeterministicHashWith(v, mask.WithSalt("salt-a", "v1"))
-	b := mask.DeterministicHashWith(v, mask.WithSalt("salt-b", "v1"))
+	a := mask.DeterministicHashFunc(mask.WithSalt("salt-a"), mask.WithSaltVersion("v1"))(v)
+	b := mask.DeterministicHashFunc(mask.WithSalt("salt-b"), mask.WithSaltVersion("v1"))(v)
 	assert.NotEqual(t, a, b)
 }
 
@@ -553,8 +553,8 @@ func TestDeterministicHash_DifferentVersions_DifferentOutputs(t *testing.T) {
 	}
 	for _, p := range pairs {
 		t.Run(p.left+"_vs_"+p.right, func(t *testing.T) {
-			a := mask.DeterministicHashWith(v, mask.WithSalt(salt, p.left))
-			b := mask.DeterministicHashWith(v, mask.WithSalt(salt, p.right))
+			a := mask.DeterministicHashFunc(mask.WithSalt(salt), mask.WithSaltVersion(p.left))(v)
+			b := mask.DeterministicHashFunc(mask.WithSalt(salt), mask.WithSaltVersion(p.right))(v)
 			assert.NotEqual(t, a, b)
 		})
 	}
@@ -567,7 +567,7 @@ func TestDeterministicHash_EmptySaltCollapsesToUnsalted(t *testing.T) {
 	const v = "alice@example.com"
 	for _, ver := range []string{"", "v1", "2026-01", "anything goes here"} {
 		t.Run("version="+ver, func(t *testing.T) {
-			withEmpty := mask.DeterministicHashWith(v, mask.WithSalt("", ver))
+			withEmpty := mask.DeterministicHashFunc(mask.WithSalt(""), mask.WithSaltVersion(ver))(v)
 			unsalted := mask.DeterministicHash(v)
 			assert.Equal(t, unsalted, withEmpty)
 		})
@@ -582,12 +582,12 @@ func TestDeterministicHash_EmptyVersionFailsClosed(t *testing.T) {
 	values := []string{"", "x", "alice@example.com", "佐藤太郎", "\xff\xfe", strings.Repeat("x", 1000), mask.FullRedactMarker}
 	for _, s := range salts {
 		for _, v := range values {
-			got := mask.DeterministicHashWith(v, mask.WithSalt(s, ""))
+			got := mask.DeterministicHashFunc(mask.WithSalt(s), mask.WithSaltVersion(""))(v)
 			assert.Equal(t, mask.FullRedactMarker, got, "salt=%q value=%q", s, v)
 		}
 	}
 	// Same via the factory.
-	r := mask.DeterministicHashFunc(mask.WithSalt("k", ""))
+	r := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion(""))
 	for _, v := range values {
 		assert.Equal(t, mask.FullRedactMarker, r(v), "factory value=%q", v)
 	}
@@ -598,7 +598,7 @@ func TestDeterministicHash_VersionRejectsColon(t *testing.T) {
 	cases := []string{"v:1", ":", ":v1", "v1:", "v::v", "a:b:c"}
 	for _, ver := range cases {
 		t.Run(ver, func(t *testing.T) {
-			got := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", ver))
+			got := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion(ver))("alice@example.com")
 			assert.Equal(t, mask.FullRedactMarker, got)
 		})
 	}
@@ -619,7 +619,7 @@ func TestDeterministicHash_VersionCharsetEnforced(t *testing.T) {
 	}
 	for _, ver := range bad {
 		t.Run("bad_"+shortVersion(ver), func(t *testing.T) {
-			got := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", ver))
+			got := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion(ver))("alice@example.com")
 			assert.Equal(t, mask.FullRedactMarker, got)
 		})
 	}
@@ -631,7 +631,7 @@ func TestDeterministicHash_VersionCharsetEnforced(t *testing.T) {
 	}
 	for _, ver := range good {
 		t.Run("good_"+shortVersion(ver), func(t *testing.T) {
-			got := mask.DeterministicHashWith("alice@example.com", mask.WithSalt("k", ver))
+			got := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion(ver))("alice@example.com")
 			assert.NotEqual(t, mask.FullRedactMarker, got)
 			assert.True(t, strings.HasPrefix(got, "sha256:"+ver+":"), "got %q", got)
 		})
@@ -662,9 +662,10 @@ func TestDeterministicHash_StickyMisconfiguration(t *testing.T) {
 	t.Parallel()
 	// Misconfigured option followed by a valid one must still produce
 	// FullRedactMarker — the sticky flag cannot be cleared.
-	got := mask.DeterministicHashWith("alice@example.com",
-		mask.WithSalt("k", "bad:version"),
-		mask.WithSalt("k", "v1"))
+	got := mask.DeterministicHashFunc(
+		mask.WithSalt("k"), mask.WithSaltVersion("bad:version"),
+		mask.WithSalt("k"), mask.WithSaltVersion("v1"),
+	)("alice@example.com")
 	assert.Equal(t, mask.FullRedactMarker, got)
 }
 
@@ -680,26 +681,28 @@ func TestDeterministicHash_BuiltInEqualsZeroOptionFactory(t *testing.T) {
 func TestDeterministicHash_OptionLastWins(t *testing.T) {
 	t.Parallel()
 	// Algorithm: last-wins collapses to SHA-256.
-	out := mask.DeterministicHashWith("x",
+	out := mask.DeterministicHashFunc(
 		mask.WithAlgorithm(mask.SHA512),
-		mask.WithAlgorithm(mask.SHA256))
+		mask.WithAlgorithm(mask.SHA256),
+	)("x")
 	assert.True(t, strings.HasPrefix(out, "sha256:"))
 
-	// Salt: WithSalt("k", "v1") then WithSalt("", "anything") reverts to
-	// the unsalted path.
-	back := mask.DeterministicHashWith("x",
-		mask.WithSalt("k", "v1"),
-		mask.WithSalt("", "anything"))
+	// Salt: setting salt+version then clearing salt to empty reverts
+	// to the unsalted path; a later version without a salt is ignored.
+	back := mask.DeterministicHashFunc(
+		mask.WithSalt("k"), mask.WithSaltVersion("v1"),
+		mask.WithSalt(""),
+	)("x")
 	unsalted := mask.DeterministicHash("x")
 	assert.Equal(t, unsalted, back)
 }
 
 func TestDeterministicHash_UnknownAlgorithmClampsToSHA256(t *testing.T) {
 	t.Parallel()
-	out := mask.DeterministicHashWith("x", mask.WithAlgorithm(mask.HashAlgorithm(99)))
+	out := mask.DeterministicHashFunc(mask.WithAlgorithm(mask.HashAlgorithm(99)))("x")
 	assert.True(t, strings.HasPrefix(out, "sha256:"))
 
-	out = mask.DeterministicHashWith("x", mask.WithAlgorithm(mask.HashAlgorithm(-1)))
+	out = mask.DeterministicHashFunc(mask.WithAlgorithm(mask.HashAlgorithm(-1)))("x")
 	assert.True(t, strings.HasPrefix(out, "sha256:"))
 }
 
@@ -734,7 +737,7 @@ func TestDeterministicHash_SaltNotLeakedInOutputOrDescribe(t *testing.T) {
 	const salt = "SEKRET"
 
 	m := mask.New()
-	require.NoError(t, m.Register("salted_hash", mask.DeterministicHashFunc(mask.WithSalt(salt, "v1"))))
+	require.NoError(t, m.Register("salted_hash", mask.DeterministicHashFunc(mask.WithSalt(salt), mask.WithSaltVersion("v1"))))
 
 	inputs := []string{
 		"",
@@ -778,7 +781,7 @@ func TestDeterministicHash_VersionDoesNotLeakSalt(t *testing.T) {
 	)
 
 	m := mask.New()
-	require.NoError(t, m.Register("salted_hash_v", mask.DeterministicHashFunc(mask.WithSalt(salt, version))))
+	require.NoError(t, m.Register("salted_hash_v", mask.DeterministicHashFunc(mask.WithSalt(salt), mask.WithSaltVersion(version))))
 
 	inputs := []string{
 		"",
@@ -816,7 +819,7 @@ func TestDeterministicHash_VersionDoesNotLeakSalt(t *testing.T) {
 
 func TestDeterministicHash_ConcurrentHashing(t *testing.T) {
 	t.Parallel()
-	r := mask.DeterministicHashFunc(mask.WithSalt("k", "v1"))
+	r := mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion("v1"))
 	want := r("alice@example.com")
 
 	const goroutines = 50
@@ -950,7 +953,7 @@ func TestPrimitives_InvalidUTF8NoPanic(t *testing.T) {
 	assert.NotPanics(t, func() { _ = mask.ReducePrecision(bad, 2, '*') })
 	assert.NotPanics(t, func() { _ = mask.DeterministicHash(bad) })
 	assert.NotPanics(t, func() {
-		_ = mask.DeterministicHashWith(bad, mask.WithSalt("k", "v1"), mask.WithAlgorithm(mask.SHA3_512))
+		_ = mask.DeterministicHashFunc(mask.WithSalt("k"), mask.WithSaltVersion("v1"), mask.WithAlgorithm(mask.SHA3_512))(bad)
 	})
 }
 

--- a/rule_names.go
+++ b/rule_names.go
@@ -1,0 +1,125 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+// Exported rule-name constants for every built-in rule registered by the
+// library. These exist so callers can opt into compile-time safety against
+// typos — `mask.Apply(mask.RuleEmailAddress, v)` instead of the stringly
+// typed `mask.Apply("email_address", v)`. String-literal call sites continue
+// to work without change.
+//
+// A drift-guard test in rule_names_test.go asserts that this set matches the
+// built-in registry one-for-one. Adding a new built-in rule without
+// declaring the matching constant here fails the build.
+
+// Utility primitives registered as named rules.
+const (
+	RuleFullRedact        = "full_redact"
+	RuleSameLengthMask    = "same_length_mask"
+	RuleNullify           = "nullify"
+	RuleDeterministicHash = "deterministic_hash"
+)
+
+// Global identity rules.
+const (
+	RuleEmailAddress        = "email_address"
+	RulePersonName          = "person_name"
+	RuleGivenName           = "given_name"
+	RuleFamilyName          = "family_name"
+	RuleStreetAddress       = "street_address"
+	RuleDateOfBirth         = "date_of_birth"
+	RuleUsername            = "username"
+	RulePassportNumber      = "passport_number"
+	RuleDriverLicenseNumber = "driver_license_number"
+	RuleGenericNationalID   = "generic_national_id"
+	RuleTaxIdentifier       = "tax_identifier"
+)
+
+// Country-specific identity rules.
+const (
+	RuleUSSSN            = "us_ssn"
+	RuleCASIN            = "ca_sin"
+	RuleUKNINO           = "uk_nino"
+	RuleINAadhaar        = "in_aadhaar"
+	RuleINPAN            = "in_pan"
+	RuleAUMedicareNumber = "au_medicare_number"
+	RuleSGNRICFIN        = "sg_nric_fin"
+	RuleBRCPF            = "br_cpf"
+	RuleBRCNPJ           = "br_cnpj"
+	RuleMXCURP           = "mx_curp"
+	RuleMXRFC            = "mx_rfc"
+	RuleCNResidentID     = "cn_resident_id"
+	RuleZANationalID     = "za_national_id"
+	RuleESDNINIFNIE      = "es_dni_nif_nie"
+)
+
+// Financial rules.
+const (
+	RulePaymentCardPAN       = "payment_card_pan"
+	RulePaymentCardPANFirst6 = "payment_card_pan_first6"
+	RulePaymentCardPANLast4  = "payment_card_pan_last4"
+	RulePaymentCardCVV       = "payment_card_cvv"
+	RulePaymentCardPIN       = "payment_card_pin"
+	RuleBankAccountNumber    = "bank_account_number"
+	RuleUKSortCode           = "uk_sort_code"
+	RuleUSABARoutingNumber   = "us_aba_routing_number"
+	RuleIBAN                 = "iban"
+	RuleSWIFTBIC             = "swift_bic"
+	RuleMonetaryAmount       = "monetary_amount"
+)
+
+// Health rules.
+const (
+	RuleMedicalRecordNumber     = "medical_record_number"
+	RuleHealthPlanBeneficiaryID = "health_plan_beneficiary_id"
+	RuleMedicalDeviceIdentifier = "medical_device_identifier"
+	RuleDiagnosisCode           = "diagnosis_code"
+	RulePrescriptionText        = "prescription_text"
+)
+
+// Technology rules.
+const (
+	RuleIPv4Address      = "ipv4_address"
+	RuleIPv6Address      = "ipv6_address"
+	RuleMACAddress       = "mac_address"
+	RuleHostname         = "hostname"
+	RuleURL              = "url"
+	RuleURLCredentials   = "url_credentials"
+	RuleAPIKey           = "api_key"
+	RuleJWTToken         = "jwt_token"
+	RuleBearerToken      = "bearer_token"
+	RulePassword         = "password"
+	RulePrivateKeyPEM    = "private_key_pem"
+	RuleConnectionString = "connection_string"
+	RuleDatabaseDSN      = "database_dsn"
+	RuleUUID             = "uuid"
+)
+
+// Telecom rules.
+const (
+	RulePhoneNumber       = "phone_number"
+	RuleMobilePhoneNumber = "mobile_phone_number"
+	RuleIMEI              = "imei"
+	RuleIMSI              = "imsi"
+	RuleMSISDN            = "msisdn"
+)
+
+// Location rules.
+const (
+	RulePostalCode     = "postal_code"
+	RuleGeoLatitude    = "geo_latitude"
+	RuleGeoLongitude   = "geo_longitude"
+	RuleGeoCoordinates = "geo_coordinates"
+)

--- a/rule_names_test.go
+++ b/rule_names_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axonops/mask"
+)
+
+// ruleNameConstants lists every exported `mask.Rule*` constant in the
+// library. The drift-guard test below asserts this set matches
+// `mask.Rules()` exactly, so a new built-in rule without a matching
+// constant — or a removed constant still referenced in the registry —
+// fails the build.
+var ruleNameConstants = []string{
+	// Utility primitives
+	mask.RuleFullRedact,
+	mask.RuleSameLengthMask,
+	mask.RuleNullify,
+	mask.RuleDeterministicHash,
+	// Global identity
+	mask.RuleEmailAddress,
+	mask.RulePersonName,
+	mask.RuleGivenName,
+	mask.RuleFamilyName,
+	mask.RuleStreetAddress,
+	mask.RuleDateOfBirth,
+	mask.RuleUsername,
+	mask.RulePassportNumber,
+	mask.RuleDriverLicenseNumber,
+	mask.RuleGenericNationalID,
+	mask.RuleTaxIdentifier,
+	// Country-specific identity
+	mask.RuleUSSSN,
+	mask.RuleCASIN,
+	mask.RuleUKNINO,
+	mask.RuleINAadhaar,
+	mask.RuleINPAN,
+	mask.RuleAUMedicareNumber,
+	mask.RuleSGNRICFIN,
+	mask.RuleBRCPF,
+	mask.RuleBRCNPJ,
+	mask.RuleMXCURP,
+	mask.RuleMXRFC,
+	mask.RuleCNResidentID,
+	mask.RuleZANationalID,
+	mask.RuleESDNINIFNIE,
+	// Financial
+	mask.RulePaymentCardPAN,
+	mask.RulePaymentCardPANFirst6,
+	mask.RulePaymentCardPANLast4,
+	mask.RulePaymentCardCVV,
+	mask.RulePaymentCardPIN,
+	mask.RuleBankAccountNumber,
+	mask.RuleUKSortCode,
+	mask.RuleUSABARoutingNumber,
+	mask.RuleIBAN,
+	mask.RuleSWIFTBIC,
+	mask.RuleMonetaryAmount,
+	// Health
+	mask.RuleMedicalRecordNumber,
+	mask.RuleHealthPlanBeneficiaryID,
+	mask.RuleMedicalDeviceIdentifier,
+	mask.RuleDiagnosisCode,
+	mask.RulePrescriptionText,
+	// Technology
+	mask.RuleIPv4Address,
+	mask.RuleIPv6Address,
+	mask.RuleMACAddress,
+	mask.RuleHostname,
+	mask.RuleURL,
+	mask.RuleURLCredentials,
+	mask.RuleAPIKey,
+	mask.RuleJWTToken,
+	mask.RuleBearerToken,
+	mask.RulePassword,
+	mask.RulePrivateKeyPEM,
+	mask.RuleConnectionString,
+	mask.RuleDatabaseDSN,
+	mask.RuleUUID,
+	// Telecom
+	mask.RulePhoneNumber,
+	mask.RuleMobilePhoneNumber,
+	mask.RuleIMEI,
+	mask.RuleIMSI,
+	mask.RuleMSISDN,
+	// Location
+	mask.RulePostalCode,
+	mask.RuleGeoLatitude,
+	mask.RuleGeoLongitude,
+	mask.RuleGeoCoordinates,
+}
+
+// TestRuleNameConstants_MatchRegistry asserts that the exported
+// constants cover exactly the set of built-in rules registered on a
+// fresh Masker. A mismatch in either direction fails the build.
+func TestRuleNameConstants_MatchRegistry(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	registered := m.Rules()
+	sort.Strings(registered)
+
+	declared := make([]string, len(ruleNameConstants))
+	copy(declared, ruleNameConstants)
+	sort.Strings(declared)
+
+	assert.Equal(t, registered, declared,
+		"exported Rule* constants must match the built-in registry one-for-one")
+}

--- a/rules_financial.go
+++ b/rules_financial.go
@@ -35,13 +35,6 @@ func isFinancialSeparator(r rune) bool {
 	return r == '-' || r == ' ' || r == '\u00A0'
 }
 
-// isASCIIDigit reports whether b is an ASCII digit (0–9).
-// Non-ASCII digit scripts (Arabic-Indic, Devanagari, etc.) return false —
-// payment-card and banking inputs are ASCII-only by spec.
-func isASCIIDigit(b byte) bool {
-	return b >= '0' && b <= '9'
-}
-
 // countDigitsAllDigits walks v, counts non-separator runes (via isSep), and
 // reports whether every non-separator rune is an ASCII digit. The single
 // pass is zero-alloc because range-looping a string does not allocate.
@@ -169,7 +162,7 @@ func maskUSABARoutingNumber(v string, c rune) string {
 		return ""
 	}
 	for i := 0; i < len(v); i++ {
-		if !isASCIIDigit(v[i]) {
+		if !isASCIIDecDigit(v[i]) {
 			return SameLengthMask(v, c)
 		}
 	}
@@ -253,7 +246,7 @@ func maskSWIFTBIC(v string, c rune) string {
 	}
 	for i := 0; i < len(v); i++ {
 		b := v[i]
-		if (b < 'A' || b > 'Z') && !isASCIIDigit(b) {
+		if (b < 'A' || b > 'Z') && !isASCIIDecDigit(b) {
 			return SameLengthMask(v, c)
 		}
 	}
@@ -284,21 +277,21 @@ func registerFinancialRules(m *Masker) {
 		func(v string) string { return maskPaymentCardPAN(v, m.maskChar()) },
 		RuleInfo{
 			Name: "payment_card_pan", Category: "financial", Jurisdiction: "global (PCI DSS)",
-			Description: "Keeps the first 6 (BIN) and the last 4 digits; preserves dashes and spaces; requires 13-19 ASCII digits. Example: 4111-2222-3333-4444 → 4111-22**-****-4444.",
+			Description: "Keeps the first 6 (BIN) and the last 4 digits; preserves dashes and spaces; requires 13-19 ASCII digits. Example: 4111-1111-1111-1111 → 4111-11**-****-1111.",
 		})
 
 	m.mustRegisterBuiltin("payment_card_pan_first6",
 		func(v string) string { return maskPaymentCardPANFirst6(v, m.maskChar()) },
 		RuleInfo{
 			Name: "payment_card_pan_first6", Category: "financial", Jurisdiction: "global (PCI DSS)",
-			Description: "Keeps only the first 6 digits (BIN); preserves dashes and spaces. Example: 4111-2222-3333-4444 → 4111-22**-****-****.",
+			Description: "Keeps only the first 6 digits (BIN); preserves dashes and spaces. Example: 4111-1111-1111-1111 → 4111-11**-****-****.",
 		})
 
 	m.mustRegisterBuiltin("payment_card_pan_last4",
 		func(v string) string { return maskPaymentCardPANLast4(v, m.maskChar()) },
 		RuleInfo{
 			Name: "payment_card_pan_last4", Category: "financial", Jurisdiction: "global (PCI DSS)",
-			Description: "Keeps only the last 4 digits; preserves dashes and spaces. Example: 4111-2222-3333-4444 → ****-****-****-4444.",
+			Description: "Keeps only the last 4 digits; preserves dashes and spaces. Example: 4111-1111-1111-1111 → ****-****-****-1111.",
 		})
 
 	m.mustRegisterBuiltin("payment_card_cvv",
@@ -351,7 +344,7 @@ func registerFinancialRules(m *Masker) {
 		})
 
 	m.mustRegisterBuiltin("monetary_amount",
-		func(_ string) string { return maskMonetaryAmount("") },
+		maskMonetaryAmount,
 		RuleInfo{
 			Name: "monetary_amount", Category: "financial", Jurisdiction: "global",
 			Description: "Replaces any value with [REDACTED]. Length-preserving output would leak order of magnitude. Example: $1,234.56 → [REDACTED].",

--- a/rules_financial_test.go
+++ b/rules_financial_test.go
@@ -17,6 +17,7 @@ package mask_test
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -344,8 +345,11 @@ func TestFinancial_NoPanicOnAdversarialInput(t *testing.T) {
 		"iban", "swift_bic", "monetary_amount",
 	} {
 		for _, in := range adversarial {
-			assert.NotPanics(t, func() { _ = m.Apply(n, in) },
+			var got string
+			assert.NotPanics(t, func() { got = m.Apply(n, in) },
 				"rule %q panicked on input %q", n, in)
+			assert.True(t, utf8.ValidString(got),
+				"rule %q produced invalid UTF-8 for input %q: %q", n, in, got)
 		}
 	}
 }

--- a/rules_identity.go
+++ b/rules_identity.go
@@ -40,10 +40,10 @@ import (
 // threat model.
 
 var (
-	// Date-of-birth format patterns. Compiled once at package init; never
-	// re-evaluated against user input, so no ReDoS surface.
-	reDOBISO       = regexp.MustCompile(`^(\d{4})-(\d{1,2})-(\d{1,2})$`)
-	reDOBSlash     = regexp.MustCompile(`^(\d{1,2})/(\d{1,2})/(\d{4})$`)
+	// reDOBMonthName matches the "Month D, YYYY" format for date_of_birth.
+	// Compiled once at package init; never re-evaluated against user input,
+	// so no ReDoS surface. The ISO and slash formats are parsed by
+	// parseDOBISO / parseDOBSlash without allocation.
 	reDOBMonthName = regexp.MustCompile(`^([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})$`)
 
 	// monthNames is the closed set of full English month names recognised
@@ -91,15 +91,33 @@ func maskEmail(v string, c rune) string {
 	if v == "" {
 		return ""
 	}
+	// UTF-8 must be valid on both halves — echoing invalid bytes
+	// via the short-local path would break the library-wide
+	// "output is always valid UTF-8" contract.
+	if !utf8.ValidString(v) {
+		return SameLengthMask(v, c)
+	}
 	i := strings.LastIndexByte(v, '@')
 	if i <= 0 || i == len(v)-1 {
 		return SameLengthMask(v, c)
 	}
 	local, domain := v[:i], v[i:] // domain includes '@'
-	if utf8.RuneCountInString(local) <= 1 {
+	// Decode just the first rune to check for a single-rune local part
+	// without a full RuneCountInString scan.
+	_, sz := utf8.DecodeRuneInString(local)
+	if sz == len(local) {
 		return v
 	}
-	return KeepFirstN(local, 1, c) + domain
+	// Build the masked result in a single allocation.
+	tailRunes := utf8.RuneCountInString(local[sz:])
+	var b strings.Builder
+	b.Grow(sz + tailRunes*safeRuneLen(c) + len(domain))
+	b.WriteString(local[:sz])
+	for j := 0; j < tailRunes; j++ {
+		b.WriteRune(c)
+	}
+	b.WriteString(domain)
+	return b.String()
 }
 
 // nameSeparators reports whether r is treated as a separator by the name
@@ -256,7 +274,7 @@ func maskStreet(v string, c rune) string {
 	if head == "" && tailOff < 0 {
 		return SameLengthMask(v, c)
 	}
-	body, tail := splitBodyAndTail(rest, tailOff)
+	body, tail, prependSpace := splitBodyAndTail(rest, tailOff)
 	// Fail-closed guard: if the recognised suffix consumed the entire
 	// non-digit portion of the input, the rule would echo v unchanged.
 	// That happens on inputs like "42 N" or "1 NE" where the whole
@@ -279,6 +297,9 @@ func maskStreet(v string, c rune) string {
 	out.WriteString(head)
 	out.WriteString(spaceAfterHead)
 	maskBodyPreservingSpaces(&out, body, c)
+	if prependSpace {
+		out.WriteByte(' ')
+	}
 	out.WriteString(tail)
 	return out.String()
 }
@@ -298,17 +319,17 @@ func splitHouseNumber(v string) (head, spaceAfter, rest string) {
 
 // splitBodyAndTail separates the body to mask from the recognised trailing
 // street-type suffix. When tailOff < 0 the whole string is body.
-func splitBodyAndTail(rest string, tailOff int) (body, tail string) {
+// prependSpace is true when a separating space must be written between the
+// masked body and the tail; the caller writes the space directly into the
+// output builder rather than allocating an intermediate string.
+func splitBodyAndTail(rest string, tailOff int) (body, tail string, prependSpace bool) {
 	if tailOff < 0 {
-		return rest, ""
+		return rest, "", false
 	}
 	body = strings.TrimRight(rest[:tailOff], " ")
 	tail = rest[tailOff:]
-	// Preserve exactly one separating space between masked body and tail.
-	if body != rest[:tailOff] {
-		tail = " " + tail
-	}
-	return body, tail
+	prependSpace = body != rest[:tailOff]
+	return body, tail, prependSpace
 }
 
 // maskBodyPreservingSpaces writes the rune-wise mask of body into b,
@@ -344,14 +365,14 @@ func maskDateOfBirth(v string, c rune) string {
 	if v == "" {
 		return ""
 	}
-	if m := reDOBISO.FindStringSubmatch(v); m != nil {
-		return buildDOB(c, m[1], "-", len(m[2]), "-", len(m[3]), "")
+	if year, mLen, dLen, ok := parseDOBISO(v); ok {
+		return buildDOB(c, year, "-", mLen, "-", dLen, "")
 	}
-	if m := reDOBSlash.FindStringSubmatch(v); m != nil {
+	if dLen, _, year, ok := parseDOBSlash(v); ok {
 		// Per spec, the middle group is always 4 stars regardless of the
 		// matched month width. See
 		// docs/v0.9.0-requirements.md §"date_of_birth" example.
-		return buildDOBPrefixedLiteral(c, len(m[1]), "/", 4, "/", m[3])
+		return buildDOBPrefixedLiteral(c, dLen, "/", 4, "/", year)
 	}
 	if m := reDOBMonthName.FindStringSubmatch(v); m != nil {
 		if monthNameRecognised(m[1]) {
@@ -359,6 +380,52 @@ func maskDateOfBirth(v string, c rune) string {
 		}
 	}
 	return SameLengthMask(v, c)
+}
+
+// parseDOBISO parses YYYY-MM-DD or YYYY-M-D without allocating.
+// Returns the year substring and the byte-lengths of the month and day fields.
+func parseDOBISO(v string) (year string, mLen, dLen int, ok bool) {
+	if len(v) < 8 {
+		return
+	}
+	if !allASCIIDigits(v[:4]) {
+		return
+	}
+	if v[4] != '-' {
+		return
+	}
+	rest := v[5:]
+	sep := strings.IndexByte(rest, '-')
+	if sep < 1 || sep > 2 || !allASCIIDigits(rest[:sep]) {
+		return
+	}
+	day := rest[sep+1:]
+	if len(day) < 1 || len(day) > 2 || !allASCIIDigits(day) {
+		return
+	}
+	return v[:4], sep, len(day), true
+}
+
+// parseDOBSlash parses D/M/YYYY or DD/MM/YYYY without allocating.
+// Returns the byte-lengths of the day and month fields and the year substring.
+func parseDOBSlash(v string) (dLen, mLen int, year string, ok bool) {
+	if len(v) < 8 {
+		return
+	}
+	sep1 := strings.IndexByte(v, '/')
+	if sep1 < 1 || sep1 > 2 || !allASCIIDigits(v[:sep1]) {
+		return
+	}
+	rest := v[sep1+1:]
+	sep2 := strings.IndexByte(rest, '/')
+	if sep2 < 1 || sep2 > 2 || !allASCIIDigits(rest[:sep2]) {
+		return
+	}
+	yr := rest[sep2+1:]
+	if len(yr) != 4 || !allASCIIDigits(yr) {
+		return
+	}
+	return sep1, sep2, yr, true
 }
 
 // buildDOB emits "<year><sep1><nMask1><sep2><nMask2><tail>" in one
@@ -484,6 +551,11 @@ func maskDriverLicense(v string, c rune) string {
 // not covered by a jurisdiction-specific rule. Keeps the first 2 and
 // last 2 runes, masks the middle.
 func maskGenericNationalID(v string, c rune) string {
+	// Fail closed on invalid UTF-8 so we never echo raw bytes via
+	// KeepFirstLast's "window >= runeCount → return v" short path.
+	if !utf8.ValidString(v) {
+		return SameLengthMask(v, c)
+	}
 	return KeepFirstLast(v, 2, 2, c)
 }
 

--- a/rules_identity_bench_test.go
+++ b/rules_identity_bench_test.go
@@ -124,6 +124,28 @@ func BenchmarkApply_date_of_birth_fallback(b *testing.B) {
 	identitySink = s
 }
 
+func BenchmarkApply_date_of_birth_slash(b *testing.B) {
+	m := mask.New()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = m.Apply("date_of_birth", "15/03/1985")
+	}
+	identitySink = s
+}
+
+func BenchmarkApply_date_of_birth_month_name(b *testing.B) {
+	m := mask.New()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = m.Apply("date_of_birth", "March 15, 1985")
+	}
+	identitySink = s
+}
+
 func BenchmarkApply_username(b *testing.B) {
 	m := mask.New()
 	b.ReportAllocs()

--- a/rules_identity_test.go
+++ b/rules_identity_test.go
@@ -17,6 +17,7 @@ package mask_test
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -361,8 +362,11 @@ func TestIdentity_NoPanicOnAdversarialInput(t *testing.T) {
 		"driver_license_number", "generic_national_id", "tax_identifier",
 	} {
 		for _, in := range adversarial {
-			assert.NotPanics(t, func() { _ = m.Apply(n, in) },
+			var got string
+			assert.NotPanics(t, func() { got = m.Apply(n, in) },
 				"rule %q panicked on input %q", n, in)
+			assert.True(t, utf8.ValidString(got),
+				"rule %q produced invalid UTF-8 for input %q: %q", n, in, got)
 		}
 	}
 }

--- a/rules_matrices_test.go
+++ b/rules_matrices_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axonops/mask"
+)
+
+// Cross-cutting per-category matrices for identity, financial, and
+// health rules. Technology, telecom, and country have equivalent
+// matrices in their own test files; these three categories were
+// flagged by the test-analyst (issue #6) as missing.
+
+// TestIdentity_IdempotencyMatrix asserts that applying a rule to its
+// own output is either stable (idempotent) or strictly-length-reducing
+// and non-revealing. Identity rules behave differently: some (person_name,
+// given_name, family_name) produce output that re-parses as a valid
+// input for the same rule and is therefore idempotent. Others collapse
+// to a fall-back on second pass.
+func TestIdentity_IdempotencyMatrix(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ rule, in string }{
+		{mask.RuleEmailAddress, "alice@example.com"},
+		{mask.RulePersonName, "John Doe"},
+		{mask.RuleGivenName, "Alice"},
+		{mask.RuleFamilyName, "Smith"},
+		{mask.RuleStreetAddress, "42 Wallaby Way"},
+		{mask.RuleDateOfBirth, "1985-03-15"},
+		{mask.RuleUsername, "johndoe42"},
+		{mask.RulePassportNumber, "GB1234567"},
+		{mask.RuleDriverLicenseNumber, "DL-1234-5678"},
+		{mask.RuleGenericNationalID, "AB123456CD"},
+		{mask.RuleTaxIdentifier, "12-3456789"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			first := m.Apply(tc.rule, tc.in)
+			second := m.Apply(tc.rule, first)
+			// The contract: re-applying the rule MUST NOT grow the output
+			// and MUST NOT reveal any of the original input.
+			assert.LessOrEqual(t, len(second), len(first),
+				"rule %q expanded output on re-application", tc.rule)
+			assert.NotContains(t, second, tc.in,
+				"rule %q leaked original input on re-application", tc.rule)
+		})
+	}
+}
+
+// TestIdentity_MaskCharOverride confirms every identity rule honours
+// the per-instance mask character. Rules that emit mask runes switch
+// from `*` to `X` when the Masker is configured with WithMaskChar('X').
+func TestIdentity_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	cases := []struct{ rule, in, want string }{
+		{mask.RuleEmailAddress, "alice@example.com", "aXXXX@example.com"},
+		{mask.RulePersonName, "John Doe", "JXXX DXX"},
+		{mask.RuleGivenName, "Alice", "AXXXX"},
+		{mask.RuleFamilyName, "Smith", "SXXXX"},
+		{mask.RuleStreetAddress, "42 Wallaby Way", "42 XXXXXXX Way"},
+		{mask.RuleDateOfBirth, "1985-03-15", "1985-XX-XX"},
+		{mask.RuleUsername, "johndoe42", "joXXXXXXX"},
+		{mask.RulePassportNumber, "GB1234567", "GBXXXXX67"},
+		{mask.RuleDriverLicenseNumber, "DL-1234-5678", "DL-XXXX-5678"},
+		{mask.RuleGenericNationalID, "AB123456CD", "ABXXXXXXCD"},
+		{mask.RuleTaxIdentifier, "12-3456789", "XX-XXX6789"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply(tc.rule, tc.in))
+		})
+	}
+}
+
+// TestFinancial_IdempotencyMatrix: every financial rule's output
+// either re-parses as a further-masked form or collapses to a fallback.
+// None of them should ever echo the original on a second pass.
+func TestFinancial_IdempotencyMatrix(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ rule, in string }{
+		{mask.RulePaymentCardPAN, "4111-1111-1111-1111"},
+		{mask.RulePaymentCardPANFirst6, "4111-1111-1111-1111"},
+		{mask.RulePaymentCardPANLast4, "4111-1111-1111-1111"},
+		{mask.RulePaymentCardCVV, "123"},
+		{mask.RulePaymentCardPIN, "1234"},
+		{mask.RuleBankAccountNumber, "12345678"},
+		{mask.RuleUKSortCode, "12-34-56"},
+		{mask.RuleUSABARoutingNumber, "123456789"},
+		{mask.RuleIBAN, "GB82WEST12345698765432"},
+		{mask.RuleSWIFTBIC, "BARCGB2L"},
+		{mask.RuleMonetaryAmount, "$1,234.56"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			first := m.Apply(tc.rule, tc.in)
+			second := m.Apply(tc.rule, first)
+			assert.LessOrEqual(t, len(second), len(first),
+				"rule %q expanded output on re-application", tc.rule)
+			assert.NotContains(t, second, tc.in,
+				"rule %q leaked original input on re-application", tc.rule)
+		})
+	}
+}
+
+// TestFinancial_MaskCharOverride pins the mask-char override for every
+// financial rule.
+func TestFinancial_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	cases := []struct{ rule, in, want string }{
+		{mask.RulePaymentCardPAN, "4111-1111-1111-1111", "4111-11XX-XXXX-1111"},
+		{mask.RulePaymentCardPANFirst6, "4111-1111-1111-1111", "4111-11XX-XXXX-XXXX"},
+		{mask.RulePaymentCardPANLast4, "4111-1111-1111-1111", "XXXX-XXXX-XXXX-1111"},
+		{mask.RulePaymentCardCVV, "123", "XXX"},
+		{mask.RulePaymentCardPIN, "1234", "XXXX"},
+		{mask.RuleBankAccountNumber, "12345678", "XXXX5678"},
+		{mask.RuleUKSortCode, "12-34-56", "12-XX-XX"},
+		{mask.RuleUSABARoutingNumber, "123456789", "XXXXX6789"},
+		{mask.RuleIBAN, "GB82WEST12345698765432", "GB82XXXXXXXXXXXXXX5432"},
+		{mask.RuleSWIFTBIC, "BARCGB2L", "BARCXXXX"},
+		// monetary_amount is a full redact — unchanged under mask-char override.
+		{mask.RuleMonetaryAmount, "$1,234.56", "[REDACTED]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply(tc.rule, tc.in))
+		})
+	}
+}
+
+// TestHealth_IdempotencyMatrix: identifier rules collapse to
+// same-length mask on re-application (the mask rune isn't a valid
+// digit/letter in the prefix parser); full-redact rules are trivially
+// idempotent.
+func TestHealth_IdempotencyMatrix(t *testing.T) {
+	t.Parallel()
+	m := mask.New()
+	cases := []struct{ rule, in string }{
+		{mask.RuleMedicalRecordNumber, "MRN-123456789"},
+		{mask.RuleHealthPlanBeneficiaryID, "HPB-987654321"},
+		{mask.RuleMedicalDeviceIdentifier, "DEV-SN-12345678"},
+		{mask.RuleDiagnosisCode, "J45.20"},
+		{mask.RulePrescriptionText, "Metformin 500mg twice daily"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			first := m.Apply(tc.rule, tc.in)
+			second := m.Apply(tc.rule, first)
+			assert.LessOrEqual(t, len(second), len(first),
+				"rule %q expanded output on re-application", tc.rule)
+			assert.NotContains(t, second, tc.in,
+				"rule %q leaked original input on re-application", tc.rule)
+		})
+	}
+}
+
+// TestHealth_MaskCharOverride pins the mask-char override for every
+// health rule.
+func TestHealth_MaskCharOverride(t *testing.T) {
+	t.Parallel()
+	m := mask.New(mask.WithMaskChar('X'))
+	cases := []struct{ rule, in, want string }{
+		{mask.RuleMedicalRecordNumber, "MRN-123456789", "MRN-XXXXX6789"},
+		{mask.RuleHealthPlanBeneficiaryID, "HPB-987654321", "HPB-XXXXX4321"},
+		{mask.RuleMedicalDeviceIdentifier, "DEV-SN-12345678", "DEV-SN-XXXX5678"},
+		// Full-redact rules emit [REDACTED] regardless of mask char.
+		{mask.RuleDiagnosisCode, "J45.20", "[REDACTED]"},
+		{mask.RulePrescriptionText, "Metformin 500mg twice daily", "[REDACTED]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rule, func(t *testing.T) {
+			assert.Equal(t, tc.want, m.Apply(tc.rule, tc.in))
+		})
+	}
+}

--- a/rules_technology.go
+++ b/rules_technology.go
@@ -511,6 +511,13 @@ func maskURL(v string, c rune) string {
 	if !urlHasSensitive(u, path) {
 		return SameLengthMask(v, c)
 	}
+	// RawQuery is the caller's raw bytes; net/url preserves non-ASCII
+	// runes there verbatim. Writing invalid UTF-8 into the output
+	// would break the library-wide "output is always valid UTF-8"
+	// contract. Fail closed rather than emit a malformed string.
+	if !utf8.ValidString(u.RawQuery) {
+		return SameLengthMask(v, c)
+	}
 	var b strings.Builder
 	b.Grow(len(v))
 	writeURLMasked(&b, u, path, c)
@@ -593,17 +600,18 @@ func isCleanAuthority(h string) bool {
 // hostHasStrayByte reports whether h contains bytes that should never
 // appear in a clean authority (they signal that net/url has accepted
 // a malformed URL whose host field is actually something else).
-// Also rejects any non-ASCII byte — emitting raw 0x80+ bytes into
-// the output could produce invalid UTF-8. Consumers that need IDN
-// support should pre-punycode the host before calling.
+// Rejects any non-ASCII byte (emitting 0x80+ bytes would produce
+// invalid UTF-8 in the output) and any ASCII control byte below 0x20
+// or the delete byte 0x7F. Consumers that need IDN support should
+// pre-punycode the host before calling.
 func hostHasStrayByte(h string) bool {
 	for i := 0; i < len(h); i++ {
 		b := h[i]
-		if b >= 0x80 {
+		if b >= 0x80 || b < 0x20 || b == 0x7F {
 			return true
 		}
 		switch b {
-		case '@', '/', '?', '#', '%', ' ', '\t', '\n', '\r':
+		case '@', '/', '?', '#', '%', ' ':
 			return true
 		}
 	}
@@ -661,8 +669,9 @@ func writeMaskedURLPath(b *strings.Builder, path string, c rune) {
 
 // writeMaskedURLQuery walks raw (u.RawQuery — bytes as transmitted),
 // preserving key bytes and `&` / `=` structurally; each value
-// becomes a fixed 4-rune mask. Keys with no `=` (bare flags) are
-// emitted verbatim. Values with no key (leading `=`) still mask.
+// becomes a fixed 4-rune mask. Pairs without a `=` (bare flags) and
+// pairs with an empty key are same-length-masked so the rule cannot
+// echo a secret that was written in the ambiguous half.
 func writeMaskedURLQuery(b *strings.Builder, raw string, c rune) {
 	pairStart := 0
 	for i := 0; i <= len(raw); i++ {
@@ -705,6 +714,13 @@ func maskURLCredentials(v string, c rune) string {
 	if !ok || u.User == nil {
 		return SameLengthMask(v, c)
 	}
+	// net/url admits non-ASCII bytes in RawQuery and percent-decodes
+	// Fragment to the raw bytes, so an input like `...#%FF` yields an
+	// invalid-UTF-8 Fragment. Emit the escaped form and validate the
+	// RawQuery bytes to keep output always-valid-UTF-8.
+	if !utf8.ValidString(u.RawQuery) {
+		return SameLengthMask(v, c)
+	}
 	var b strings.Builder
 	b.Grow(len(v))
 	b.WriteString(u.Scheme)
@@ -718,7 +734,7 @@ func maskURLCredentials(v string, c rune) string {
 	}
 	if u.Fragment != "" {
 		b.WriteByte('#')
-		b.WriteString(u.Fragment)
+		b.WriteString(u.EscapedFragment())
 	}
 	return b.String()
 }
@@ -813,7 +829,10 @@ func maskBearerToken(v string, c rune) string {
 	}
 	token := v[len(bearerSchemePrefix):]
 	tokenRunes := utf8.RuneCountInString(token)
-	if tokenRunes < bearerTokenKeep {
+	// `<` would admit a token of exactly 6 runes to pass through
+	// unmasked (nothing left after the preserved prefix). Use `<=` so
+	// a 6-rune token fails closed rather than echoing the whole secret.
+	if tokenRunes <= bearerTokenKeep {
 		return SameLengthMask(v, c)
 	}
 	// Byte offset at rune 6.
@@ -859,6 +878,13 @@ func maskConnectionString(v string, c rune) string {
 	if !ok || (u.User == nil && !queryHasSecret(u.RawQuery)) {
 		return SameLengthMask(v, c)
 	}
+	// RawQuery may contain raw non-UTF-8 bytes per net/url's lax
+	// tokeniser. Fragment is masked to a fixed block so it's safe,
+	// but the query is written through writeConnStringQuery which
+	// passes pair bytes through. Fail closed on invalid UTF-8.
+	if !utf8.ValidString(u.RawQuery) {
+		return SameLengthMask(v, c)
+	}
 	var b strings.Builder
 	b.Grow(len(v))
 	b.WriteString(u.Scheme)
@@ -880,7 +906,10 @@ func maskConnectionString(v string, c rune) string {
 }
 
 // queryHasSecret scans raw for any secret-key pair. Matches the key
-// case-insensitively against [secretQueryKeys].
+// case-insensitively against [secretQueryKeys] AFTER percent-decoding
+// the raw-byte key — without the decode, an attacker-crafted key like
+// `password%3Dfoo` would bypass the lookup and the caller would echo
+// the associated value verbatim.
 func queryHasSecret(raw string) bool {
 	if raw == "" {
 		return false
@@ -890,7 +919,7 @@ func queryHasSecret(raw string) bool {
 		if i == len(raw) || raw[i] == '&' {
 			pair := raw[pairStart:i]
 			if eq := strings.IndexByte(pair, '='); eq > 0 {
-				if _, ok := secretQueryKeys[asciiLower(pair[:eq])]; ok {
+				if isSecretKey(pair[:eq]) {
 					return true
 				}
 			}
@@ -898,6 +927,21 @@ func queryHasSecret(raw string) bool {
 		}
 	}
 	return false
+}
+
+// isSecretKey reports whether rawKey names one of the configured
+// secret-query-parameter keys. Percent-decodes rawKey first so that
+// encoded variants (for example `password%3Dfoo`) do not slip past
+// the lookup. On decode failure the raw lowercased bytes are used —
+// a malformed percent sequence is unusual in a key position and we
+// prefer to fail closed toward matching.
+func isSecretKey(rawKey string) bool {
+	decoded, err := url.QueryUnescape(rawKey)
+	if err != nil {
+		decoded = rawKey
+	}
+	_, ok := secretQueryKeys[asciiLower(decoded)]
+	return ok
 }
 
 // writeConnStringQuery walks raw and emits each pair with `key=****`
@@ -927,7 +971,7 @@ func writeConnStringPair(b *strings.Builder, pair string, c rune) {
 		return
 	}
 	key := pair[:eq]
-	if _, ok := secretQueryKeys[asciiLower(key)]; ok {
+	if isSecretKey(key) {
 		b.WriteString(key)
 		b.WriteByte('=')
 		writeMaskRunes(b, c, fixedMaskWidth)
@@ -973,7 +1017,7 @@ func maskDatabaseDSN(v string, c rune) string {
 	}
 	userinfo := v[:candidate]
 	rest := v[candidate+1:]
-	if userinfo == "" || rest == "" {
+	if userinfo == "" || rest == "" || !utf8.ValidString(rest) {
 		return SameLengthMask(v, c)
 	}
 	var b strings.Builder

--- a/rules_technology_bench_test.go
+++ b/rules_technology_bench_test.go
@@ -82,6 +82,9 @@ func BenchmarkApply_url_invalid(b *testing.B) { runBench(b, "url", "not a url") 
 func BenchmarkApply_url_credentials(b *testing.B) {
 	runBench(b, "url_credentials", "https://admin:s3cret@db.example.com/mydb")
 }
+func BenchmarkApply_url_credentials_invalid(b *testing.B) {
+	runBench(b, "url_credentials", "not-a-url-at-all")
+}
 
 // ---------- api_key ----------
 

--- a/rules_telecom.go
+++ b/rules_telecom.go
@@ -492,7 +492,7 @@ func registerTelecomRules(m *Masker) {
 	m.mustRegisterBuiltin("mobile_phone_number", phone,
 		RuleInfo{
 			Name: "mobile_phone_number", Category: "telecom", Jurisdiction: "global",
-			Description: "Alias of `phone_number`; preserves +NN country code and last 4 digits, masks the middle. The spec notes mobile-specific jurisdictions may diverge; operators needing that should register a custom rule. Example: +44 7911 123456 → +44 **** **3456.",
+			Description: "Currently a thin alias of `phone_number` — identical input-to-output behaviour. Exists so callers with mobile-specific schema naming can register that name without re-wrapping. Prefer `phone_number` unless you specifically need the mobile spelling; register a distinct custom rule if future jurisdictional divergence matters to your workload. Example: +44 7911 123456 → +44 **** **3456.",
 		})
 	m.mustRegisterBuiltin("imei",
 		func(v string) string { return maskIMEI(v, m.maskChar()) },

--- a/tests/bdd/features/country.feature
+++ b/tests/bdd/features/country.feature
@@ -26,10 +26,12 @@ Feature: Country-specific identity masking rules
     Then the result is "<expected>"
 
     Examples:
-      | input       | expected    |
-      | 123-456-789 | ***-***-789 |
-      | 123456789   | ******789   |
-      |             |             |
+      | input        | expected    |
+      | 123-456-789  | ***-***-789 |
+      | 123456789    | ******789   |
+      | 12345678     | ********    |
+      | 1234-56-789  | *********** |
+      |              |             |
 
   Scenario Outline: Mask UK National Insurance Numbers
     Given a fresh masker
@@ -52,6 +54,8 @@ Feature: Country-specific identity masking rules
       | input          | expected       |
       | 1234 5678 9012 | **** **** 9012 |
       | 123456789012   | ********9012   |
+      | 12345678901    | ***********    |
+      | 1234 5678 901  | *************  |
       |                |                |
 
   Scenario Outline: Mask Indian PAN
@@ -63,6 +67,8 @@ Feature: Country-specific identity masking rules
       | input      | expected   |
       | ABCDE1234F | ABC*****4F |
       | abcde1234f | ********** |
+      | ABCDE12345 | ********** |
+      | ABCD1234FG | ********** |
       |            |            |
 
   Scenario Outline: Mask Australian Medicare numbers
@@ -76,6 +82,8 @@ Feature: Country-specific identity masking rules
       | input        | expected     |
       | 2123 45670 1 | **** ****0 1 |
       | 2123456701   | ********01   |
+      | 212345670    | *********    |
+      | 2123 45670 1A| ************* |
       |              |              |
 
   Scenario Outline: Mask Singapore NRIC/FIN
@@ -86,7 +94,9 @@ Feature: Country-specific identity masking rules
     Examples:
       | input     | expected  |
       | S1234567A | S*******A |
+      | T7654321B | T*******B |
       | s1234567a | ********* |
+      | S123A     | *****     |
       |           |           |
 
   Scenario Outline: Mask Brazilian CPF
@@ -111,6 +121,8 @@ Feature: Country-specific identity masking rules
       | input              | expected           |
       | 12.345.678/0001-95 | **.***.***/****-95 |
       | 12345678000195     | ************95     |
+      | 12-345-678/0001-95 | ****************** |
+      | 12.345.678/0001-9  | *****************  |
       |                    |                    |
 
   Scenario Outline: Mask Mexican CURP
@@ -123,6 +135,9 @@ Feature: Country-specific identity masking rules
     Examples:
       | input              | expected           |
       | GAPA850101HDFRRL09 | GAPA***********L09 |
+      | HEGG560427MVZRRL04 | HEGG***********L04 |
+      | gapa850101hdfrrl09 | ****************** |
+      | GAPA850101HDFRRL0  | *****************  |
       |                    |                    |
 
   Scenario Outline: Mask Mexican RFC
@@ -134,6 +149,8 @@ Feature: Country-specific identity masking rules
       | input         | expected      |
       | GAPA8501014T3 | GAP*******4T3 |
       | ABC850101DEF  | ABC******DEF  |
+      | gapa8501014t3 | ************* |
+      | ABC850101     | *********     |
       |               |               |
 
   Scenario Outline: Mask Chinese Resident Identity Card numbers
@@ -155,10 +172,12 @@ Feature: Country-specific identity masking rules
     Then the result is "<expected>"
 
     Examples:
-      | input         | expected      |
-      | 8501015009087 | 850101***9087 |
-      | 850101500908  | ************  |
-      |               |               |
+      | input          | expected       |
+      | 8501015009087  | 850101***9087  |
+      | 9001010000005  | 900101***0005  |
+      | 850101500908   | ************   |
+      | 85010150090870 | ************** |
+      |                |                |
 
   Scenario Outline: Mask Spanish DNI/NIF/NIE
     Given a fresh masker

--- a/tests/bdd/features/financial.feature
+++ b/tests/bdd/features/financial.feature
@@ -34,6 +34,7 @@ Feature: Financial masking rules
       | input                | expected             |
       | 4111222233334444     | 411122**********     |
       | 4111-2222-3333-4444  | 4111-22**-****-****  |
+      | 5555444433332222     | 555544**********     |
       | 411122223333         | ************         |
 
   Scenario Outline: Mask payment card PAN keeping only last 4
@@ -45,6 +46,9 @@ Feature: Financial masking rules
       | input                | expected             |
       | 4111222233334444     | ************4444     |
       | 4111-2222-3333-4444  | ****-****-****-4444  |
+      | 5555-4444-3333-2222  | ****-****-****-2222  |
+      | 1234                 | ****                 |
+      |                      |                      |
 
   Scenario Outline: Mask payment card CVV
     Given a fresh masker
@@ -56,6 +60,8 @@ Feature: Financial masking rules
       | 123   | ***      |
       | 1234  | ****     |
       | abc   | ***      |
+      | 9876  | ****     |
+      |       |          |
 
   Scenario Outline: Mask payment card PIN
     Given a fresh masker
@@ -66,6 +72,9 @@ Feature: Financial masking rules
       | input  | expected |
       | 1234   | ****     |
       | 123456 | ******   |
+      | 0000   | ****     |
+      | abc1   | ****     |
+      |        |          |
 
   Scenario Outline: Mask bank account numbers
     Given a fresh masker
@@ -76,6 +85,9 @@ Feature: Financial masking rules
       | input          | expected       |
       | 12345678       | ****5678       |
       | 1234-5678-9012 | ****-****-9012 |
+      | 9876543210     | ******3210     |
+      | 123            | ***            |
+      |                |                |
 
   Scenario Outline: Mask UK sort codes
     Given a fresh masker
@@ -86,7 +98,9 @@ Feature: Financial masking rules
       | input    | expected |
       | 12-34-56 | 12-**-** |
       | 123456   | 12****   |
+      | 12 34 56 | 12 ** ** |
       | 12345    | *****    |
+      |          |          |
 
   Scenario Outline: Mask US ABA routing numbers
     Given a fresh masker
@@ -96,7 +110,10 @@ Feature: Financial masking rules
     Examples:
       | input     | expected  |
       | 021000021 | *****0021 |
-      | 02100002  | ******** |
+      | 123456789 | *****6789 |
+      | 02100002  | ********  |
+      | abc       | ***       |
+      |           |           |
 
   Scenario Outline: Mask IBANs
     # Spec prose requires "country code, check digits, and last 4"
@@ -122,11 +139,12 @@ Feature: Financial masking rules
     Then the result is "<expected>"
 
     Examples:
-      | input       | expected    |
-      | BARCGB2L    | BARC****    |
-      | DEUTDEFF500 | DEUT******* |
-      | barcgb2l    | ********    |
-      | BARCGB      | ******      |
+      | input        | expected     |
+      | BARCGB2L     | BARC****     |
+      | DEUTDEFF500  | DEUT*******  |
+      | DEUTDEFF1234 | ************ |
+      | barcgb2l     | ********     |
+      | BARCGB       | ******       |
 
   Scenario Outline: Mask monetary amounts
     Given a fresh masker

--- a/tests/bdd/features/health.feature
+++ b/tests/bdd/features/health.feature
@@ -86,6 +86,8 @@ Feature: Health masking rules
     Examples:
       | input                       |
       | Metformin 500mg twice daily |
+      | Lisinopril 10mg daily       |
+      | [REDACTED]                  |
       |                             |
       | メトホルミン 500mg          |
 

--- a/tests/bdd/features/identity.feature
+++ b/tests/bdd/features/identity.feature
@@ -97,6 +97,9 @@ Feature: Identity masking rules
       | input     | expected  |
       | johndoe42 | jo******* |
       | admin     | ad***     |
+      | alice_42  | al******  |
+      | x         | x         |
+      |           |           |
 
   Scenario Outline: Mask passport numbers
     Given a fresh masker
@@ -119,7 +122,9 @@ Feature: Identity masking rules
       | input            | expected            |
       | DL-1234-5678     | DL-****-5678        |
       | SMITH901015JN9AA | SM***********9AA    |
+      | D 1234 5678      | D 1*** 5678         |
       | A-B              | ***                 |
+      |                  |                     |
 
   Scenario Outline: Mask generic national identifiers
     Given a fresh masker
@@ -130,6 +135,9 @@ Feature: Identity masking rules
       | input        | expected     |
       | AB123456CD   | AB******CD   |
       | 佐藤1234太郎 | 佐藤****太郎 |
+      | 123456789    | 12*****89    |
+      | ABCD         | ABCD         |
+      |              |              |
 
   Scenario Outline: Every identity rule returns empty on empty input
     Given a fresh masker
@@ -161,3 +169,4 @@ Feature: Identity masking rules
       | 1234            | *234           |
       | 12345678        | ****5678       |
       | 123.456.789-10  | ***.***.*89-10 |
+      | **-***6789      | **-***6789     |

--- a/tests/bdd/features/technology.feature
+++ b/tests/bdd/features/technology.feature
@@ -163,6 +163,8 @@ Feature: Technology and infrastructure masking rules
       | input       | expected |
       | MyP@ssw0rd! | ******** |
       | x           | ******** |
+      | a           | ******** |
+      | longpassword | ******** |
       |             |          |
 
   Scenario: Password rule honours per-instance mask character
@@ -178,6 +180,8 @@ Feature: Technology and infrastructure masking rules
     Examples:
       | input                                 |
       | -----BEGIN RSA PRIVATE KEY-----\nMIIE |
+      | -----BEGIN EC PRIVATE KEY-----        |
+      | -----BEGIN OPENSSH PRIVATE KEY-----   |
       |                                       |
       | garbage input                         |
 

--- a/tests/bdd/features/telecom.feature
+++ b/tests/bdd/features/telecom.feature
@@ -34,6 +34,9 @@ Feature: Telecom and location masking rules
       | input            | expected         |
       | +44 7911 123456  | +44 **** **3456  |
       | 07911 123456     | ***** **3456     |
+      | (555) 123-4567   | (***) ***-4567   |
+      | 1-800-FLOWERS    | *************    |
+      |                  |                  |
 
   Scenario Outline: Mask IMEIs
     Given a fresh masker
@@ -55,7 +58,9 @@ Feature: Telecom and location masking rules
     Examples:
       | input              | expected           |
       | 310260123456789    | 31026******6789    |
+      | 234150000123456    | 23415******3456    |
       | 31026012345678     | **************     |
+      | 3102601234567890   | ****************   |
       |                    |                    |
 
   Scenario Outline: Mask MSISDNs
@@ -111,6 +116,8 @@ Feature: Telecom and location masking rules
       | input         | expected       |
       | -122.4194155  | -122.41*****   |
       | 139.6503      | 139.65**       |
+      | 0.12345       | 0.12***        |
+      | 180           | ***            |
       |               |                |
 
   Scenario Outline: Mask geo coordinate pairs

--- a/tests/bdd/steps/primitives_steps.go
+++ b/tests/bdd/steps/primitives_steps.go
@@ -128,7 +128,7 @@ func (w *World) useDeterministicHashAlgo(v, algoLabel string) error {
 	if err != nil {
 		return err
 	}
-	w.lastResult = mask.DeterministicHashWith(v, mask.WithAlgorithm(algo))
+	w.lastResult = mask.DeterministicHashFunc(mask.WithAlgorithm(algo))(v)
 	return nil
 }
 
@@ -137,17 +137,27 @@ func (w *World) useDeterministicHashAlgoSaltVersion(v, algoLabel, salt, version 
 	if err != nil {
 		return err
 	}
-	w.lastResult = mask.DeterministicHashWith(v, mask.WithAlgorithm(algo), mask.WithSalt(salt, version))
+	w.lastResult = mask.DeterministicHashFunc(
+		mask.WithAlgorithm(algo),
+		mask.WithSalt(salt),
+		mask.WithSaltVersion(version),
+	)(v)
 	return nil
 }
 
 func (w *World) useDeterministicHashSaltVersion(v, salt, version string) error {
-	w.lastResult = mask.DeterministicHashWith(v, mask.WithSalt(salt, version))
+	w.lastResult = mask.DeterministicHashFunc(
+		mask.WithSalt(salt),
+		mask.WithSaltVersion(version),
+	)(v)
 	return nil
 }
 
 func (w *World) useDeterministicHashSaltVersionSecond(v, salt, version string) error {
-	w.secondResult = mask.DeterministicHashWith(v, mask.WithSalt(salt, version))
+	w.secondResult = mask.DeterministicHashFunc(
+		mask.WithSalt(salt),
+		mask.WithSaltVersion(version),
+	)(v)
 	return nil
 }
 

--- a/tests/bdd/steps/steps.go
+++ b/tests/bdd/steps/steps.go
@@ -22,31 +22,41 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cucumber/godog"
 
 	"github.com/axonops/mask"
 )
 
+// globalRuleSeq supplies a monotonic suffix for rules registered on
+// the package-level registry inside scenarios. The registry has no
+// Deregister method; without a unique suffix, `go test -count=N`
+// reruns would collide on a fixed rule name.
+var globalRuleSeq atomic.Uint64
+
 // World holds per-scenario state shared across step implementations.
 type World struct {
-	maskers        map[string]*mask.Masker
-	lastResult     string
-	lastResults    []string
-	secondResult   string
-	replaceResult  string
-	replaceErr     error
-	lastError      error
-	lastRules      []string
-	lastDescribe   mask.RuleInfo
-	lastDescribeOK bool
+	maskers         map[string]*mask.Masker
+	globalRuleNames map[string]string // Gherkin name → actual registered name
+	lastResult      string
+	lastResults     []string
+	secondResult    string
+	replaceResult   string
+	replaceErr      error
+	lastError       error
+	lastRules       []string
+	lastDescribe    mask.RuleInfo
+	lastDescribeOK  bool
 }
 
 // newWorld returns a fresh scenario state.
 func newWorld() *World {
 	return &World{
-		maskers: map[string]*mask.Masker{},
+		maskers:         map[string]*mask.Masker{},
+		globalRuleNames: map[string]string{},
 	}
 }
 
@@ -180,7 +190,13 @@ func (w *World) registerReverseRule(name string) error {
 }
 
 func (w *World) registerReverseRuleGlobal(name string) error {
-	w.lastError = mask.Register(name, reverse)
+	// Mangle the caller's name with a process-wide monotonic suffix
+	// so repeated scenario invocations (go test -count=N, or multiple
+	// Before hooks inside a single run) do not collide on the
+	// package-level registry, which has no Deregister by design.
+	globalName := name + "_" + strconv.FormatUint(globalRuleSeq.Add(1), 10)
+	w.globalRuleNames[name] = globalName
+	w.lastError = mask.Register(globalName, reverse)
 	return w.lastError
 }
 
@@ -208,6 +224,12 @@ func (w *World) maskWithRule(value, rule string) error {
 }
 
 func (w *World) maskWithRuleGlobal(value, rule string) error {
+	// Translate the Gherkin-level rule name to its suffix-mangled
+	// form registered by registerReverseRuleGlobal, so scenarios
+	// survive `go test -count=N` against a shared registry.
+	if actual, ok := w.globalRuleNames[rule]; ok {
+		rule = actual
+	}
 	w.lastResult = mask.Apply(rule, value)
 	return nil
 }


### PR DESCRIPTION
## Summary

Holistic release-readiness pass incorporating findings from all 8 review agents. Closes #6.

### API changes (pre-1.0, breaking accepted)
- `WithSalt(salt, version)` split into `WithSalt` + `WithSaltVersion` (sticky misconfiguration preserved via incremental reconcile)
- `DeterministicHashWith` removed — use `DeterministicHashFunc(opts...)(v)`
- `Masker.MaskChar()` + `DescribeAll()` exposed
- 68 `mask.RuleX` constants with drift-guard test
- `mobile_phone_number` docs strengthened to explicitly call out its alias nature

### Code correctness
- Root-cause UTF-8 validity guards in `KeepFirstN`/`KeepLastN`/`KeepFirstLast` primitives plus rule-level guards in URL family, email, generic_national_id
- `connection_string` URL-encoded secret-key bypass fixed (percent-decode before lookup)
- `bearer_token` exactly-6-rune tokens now fail closed
- `hostHasStrayByte` rejects control bytes
- `RuleInfo` godoc corrected to match reality

### Performance
- `maskEmail` / `maskStreet` / `maskDateOfBirth` paths from 2-3 allocs → 1 alloc
- Missing benchmarks added (date_of_birth_slash, date_of_birth_month_name, url_credentials_invalid)

### Documentation (user-facing)
- README Custom Rules section rewritten into 5 patterns + 4 factory shapes + compile-time safety + per-instance scoping, every snippet showing input → output
- README Regulatory positioning matrix (PCI / HIPAA / GDPR)
- README Install step (go get + Go version requirement)
- README Quick Start error-handling note for `Register`
- README thread-safety failure-mode wording
- `doc.go` gained `# Deterministic hashing` section for pkg.go.dev readers
- SECURITY.md "Unsalted default" warning
- CHANGELOG `[0.9.0] — 2026-04-18` with correct compare links
- Factory functions README table gained Example column
- Input → output `Example:` added to every exported function godoc

### CI
- New `apache-header-guard` job (every .go carries Apache 2.0 header)
- Release workflow non-main guard (real releases only from `refs/heads/main`)
- Release workflow dry-run checkout fallback to `github.ref`
- Coverage threshold enforced at 90%

### Tests
- 3 new cross-cutting matrices (idempotency + mask-char override) for identity, financial, health
- 24 BDD scenario outlines expanded to ≥4 example rows
- Targeted pins for tax_identifier, swift_bic, mobile_phone_number, prescription_text, password, private_key_pem
- Internal coverage test for defensive branches
- `rule_names_test.go` drift-guard
- UTF-8 validity assertions in identity + financial NoPanic matrices

## Acceptance criteria (issue #6)
- [x] `make check` clean (vet, lint 0 issues, race, BDD strict, 97.9% coverage, govulncheck)
- [x] Cross-platform CI verified (linux/amd64, darwin/arm64, windows/amd64)
- [x] All 8 reviewers returned with no remaining BLOCKING findings
- [x] `goreleaser release --snapshot --clean` exits 0
- [x] No `TODO`/`FIXME`/`HACK`/`BUG` without an issue reference
- [x] No AI attribution (standing rule)
- [x] `go mod tidy` clean
- [x] `CHANGELOG` finalised for v0.9.0
- [x] Apache 2.0 header on every .go file (newly CI-enforced)
- [x] Release workflow dry-run support verified
- [x] 100× `TestConcurrent_Apply_IsSafe` clean under `-race`

Branch protection on `main` — deferred to post-release per user instruction, tracked as standing task.

Closes #6.