### PR TITLE
ci: wire benchstat regression guard into CI (closes #17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,9 +405,17 @@ jobs:
   benchstat-regression-guard:
     name: Benchmark regression guard
     runs-on: ubuntu-latest
-    # Skip on Dependabot-authored PRs: the shared-runner jitter plus
-    # third-party dependency bumps cannot legitimately move our in-tree
-    # benchmarks, so any variance there is noise.
+    # CAVEAT: ubuntu-latest is a shared GitHub-hosted runner. Shared
+    # runners exhibit ±5-15% variance between runs for nanosecond-scale
+    # benchmarks, which can fire the guard on pure jitter. If this job
+    # flakes repeatedly, options are (a) move to a dedicated runner,
+    # (b) raise the time/op threshold (keeping allocs/op strict since
+    # allocation counts are deterministic), or (c) make the job
+    # advisory rather than blocking. See CONTRIBUTING.md §Performance
+    # baseline for the policy.
+    #
+    # Skip on Dependabot-authored PRs: dependency bumps cannot
+    # legitimately move in-tree benchmarks, so variance there is noise.
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             fmt
             fmt-check
             bench
+            bench-regression
             coverage
             tidy
             tidy-check
@@ -400,3 +401,28 @@ jobs:
           distribution: goreleaser
           version: v2.7.0
           args: check
+
+  benchstat-regression-guard:
+    name: Benchmark regression guard
+    runs-on: ubuntu-latest
+    # Skip on Dependabot-authored PRs: the shared-runner jitter plus
+    # third-party dependency bumps cannot legitimately move our in-tree
+    # benchmarks, so any variance there is noise.
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20240730213412-bd2cd0152fca
+      - name: Run make bench-regression
+        run: make bench-regression
+      - name: Attach benchstat report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchstat-report
+          path: bench-regression.txt
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
           go-version: "1.26"
           cache: true
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20240730213412-bd2cd0152fca
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260409210113-8e83ce0f7b1c
       - name: Run make bench-regression
         run: make bench-regression
       - name: Attach benchstat report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,36 @@ Before opening a PR, run the full quality gate (`make check`). Internally this p
 
 See `CLAUDE.md` (developer-local, not checked into the repo) for the authoritative project-specific testing requirements.
 
+### Performance baseline
+
+`bench.txt` at the repo root is the committed benchmark baseline. CI runs the `benchstat-regression-guard` job on every PR, which compares a fresh benchmark run against `bench.txt` and fails the build if any measurement regresses beyond the threshold.
+
+**Thresholds (enforced by `scripts/check-bench-regression.sh`):**
+
+- `time/op`: any regression of 10% or more at p ≤ 0.05 fails the build.
+- `allocs/op`: any increase at all fails the build.
+- `alloc/op` (bytes): same threshold as `time/op`.
+
+**Checking locally before pushing:**
+
+```sh
+go install golang.org/x/perf/cmd/benchstat@latest
+make bench-regression
+```
+
+The target runs `go test -bench=. -benchmem -run=^$ -count=5 .`, pipes through `benchstat`, and exits non-zero if any regression crosses the threshold. The full report is written to `bench-regression.txt`.
+
+**Regenerating the baseline after a legitimate optimisation:**
+
+```sh
+make bench > bench.txt
+# Manually trim the trailing 'PASS' / 'ok' lines so the file ends with
+# the final Benchmark* line. Commit the updated bench.txt in the same
+# PR as the optimisation.
+```
+
+**Reading a regression report:** benchstat prints three tables — `time/op`, `alloc/op`, `allocs/op` — each with `old`, `new`, and `delta` columns. A row with `+5.00%` and `(p=0.000 n=5+5)` means 5% slower with high statistical significance. A `~` in the delta column means no measurable change. The guard fires on positive deltas above threshold; negative deltas (improvements) are always accepted.
+
 ## Code standards
 
 - Google Go Style Guide baseline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ make bench > bench.txt
 
 **Reading a regression report:** benchstat prints three tables — `time/op`, `alloc/op`, `allocs/op` — each with `old`, `new`, and `delta` columns. A row with `+5.00%` and `(p=0.000 n=5+5)` means 5% slower with high statistical significance. A `~` in the delta column means no measurable change. The guard fires on positive deltas above threshold; negative deltas (improvements) are always accepted.
 
+> **Known caveat — shared-runner noise.** The guard currently runs on `ubuntu-latest`, a shared GitHub-hosted runner. Those runners share CPU with neighbouring workloads and exhibit ±5-15% variance between runs for nanosecond-scale benchmarks, which can fire this guard on pure jitter. We are watching it in practice; if it flakes repeatedly we will either (a) move the job to a dedicated runner, (b) raise the time/op threshold (keeping `allocs/op` strict since allocation counts are deterministic), or (c) make the job advisory-only rather than build-blocking. If you see a regression report on a PR that does not touch the hot path and re-running CI clears it, that is likely what happened — flag it on the PR and we will tune the threshold.
+
 ## Code standards
 
 - Google Go Style Guide baseline.

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,18 @@ fmt-check: ## Fail if any Go file is unformatted
 bench: ## Run benchmarks
 	$(GO) test -bench=. -benchmem -run=^$$ $(PKG)
 
+.PHONY: bench-regression
+bench-regression: ## Compare this tree against bench.txt and fail on regression
+	@if ! command -v benchstat >/dev/null 2>&1; then \
+		echo "benchstat not installed. Install with: go install golang.org/x/perf/cmd/benchstat@latest"; \
+		exit 2; \
+	fi
+	@echo "Running benchmarks at count=5 (fresh samples for benchstat)..."
+	@$(GO) test -bench=. -benchmem -run=^$$ -count=5 $(PKG) > current.txt
+	@echo "Comparing against committed baseline (bench.txt) via benchstat..."
+	@benchstat bench.txt current.txt | tee bench-regression.txt
+	@./scripts/check-bench-regression.sh bench-regression.txt
+
 .PHONY: coverage
 coverage: ## Generate coverage profile and HTML report for the library
 	$(GO) test -race -coverprofile=$(COVER_OUT) -covermode=atomic .

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@
 
 ---
 
-<details>
-<summary><b>Table of contents</b></summary>
+**Table of contents**
 
 - [⚠️ Status](#-status)
 - [🔍 Overview](#-overview)
@@ -36,8 +35,6 @@
 - [🤝 Contributing](#-contributing)
 - [🔐 Security](#-security)
 - [📄 Licence](#-licence)
-
-</details>
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -743,6 +743,8 @@ make bench > bench.txt
 
 **Reading a regression report:** benchstat prints three tables — `time/op`, `alloc/op`, `allocs/op` — each with `old`, `new`, and `delta` columns. A row with `+5.00%` and `(p=0.000 n=5+5)` means 5% slower with high statistical significance. A `~` in the delta column means no measurable change. The guard fires on positive deltas above threshold; negative deltas (improvements) are always accepted.
 
+> **Known caveat — shared-runner noise.** The guard currently runs on `ubuntu-latest`, a shared GitHub-hosted runner. Those runners share CPU with neighbouring workloads and exhibit ±5-15% variance between runs for nanosecond-scale benchmarks, which can fire this guard on pure jitter. We are watching it in practice; if it flakes repeatedly we will either (a) move the job to a dedicated runner, (b) raise the time/op threshold (keeping `allocs/op` strict since allocation counts are deterministic), or (c) make the job advisory-only rather than build-blocking. If you see a regression report on a PR that does not touch the hot path and re-running CI clears it, that is likely what happened — flag it on the PR and we will tune the threshold.
+
 ## Code standards
 
 - Google Go Style Guide baseline.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -163,8 +163,7 @@ Full catalogue: runtime via `mask.Rules()` and `mask.Describe(name)`; static ref
 
 ---
 
-<details>
-<summary><b>Table of contents</b></summary>
+**Table of contents**
 
 - [⚠️ Status](#-status)
 - [🔍 Overview](#-overview)
@@ -183,8 +182,6 @@ Full catalogue: runtime via `mask.Rules()` and `mask.Describe(name)`; static ref
 - [🤝 Contributing](#-contributing)
 - [🔐 Security](#-security)
 - [📄 Licence](#-licence)
-
-</details>
 
 ---
 
@@ -715,6 +712,36 @@ Before opening a PR, run the full quality gate (`make check`). Internally this p
 - Benchmarks live in `*_bench_test.go` files and call `b.ReportAllocs()`.
 
 See `CLAUDE.md` (developer-local, not checked into the repo) for the authoritative project-specific testing requirements.
+
+### Performance baseline
+
+`bench.txt` at the repo root is the committed benchmark baseline. CI runs the `benchstat-regression-guard` job on every PR, which compares a fresh benchmark run against `bench.txt` and fails the build if any measurement regresses beyond the threshold.
+
+**Thresholds (enforced by `scripts/check-bench-regression.sh`):**
+
+- `time/op`: any regression of 10% or more at p ≤ 0.05 fails the build.
+- `allocs/op`: any increase at all fails the build.
+- `alloc/op` (bytes): same threshold as `time/op`.
+
+**Checking locally before pushing:**
+
+```sh
+go install golang.org/x/perf/cmd/benchstat@latest
+make bench-regression
+```
+
+The target runs `go test -bench=. -benchmem -run=^$ -count=5 .`, pipes through `benchstat`, and exits non-zero if any regression crosses the threshold. The full report is written to `bench-regression.txt`.
+
+**Regenerating the baseline after a legitimate optimisation:**
+
+```sh
+make bench > bench.txt
+# Manually trim the trailing 'PASS' / 'ok' lines so the file ends with
+# the final Benchmark* line. Commit the updated bench.txt in the same
+# PR as the optimisation.
+```
+
+**Reading a regression report:** benchstat prints three tables — `time/op`, `alloc/op`, `allocs/op` — each with `old`, `new`, and `delta` columns. A row with `+5.00%` and `(p=0.000 n=5+5)` means 5% slower with high statistical significance. A `~` in the delta column means no measurable change. The guard fires on positive deltas above threshold; negative deltas (improvements) are always accepted.
 
 ## Code standards
 

--- a/makefile_targets_test.go
+++ b/makefile_targets_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMakefileHasBenchRegressionTarget is a defence against accidentally
+// deleting the bench-regression target. The CI benchstat-regression-guard
+// job invokes `make bench-regression`; if the target disappears the
+// guard silently exits zero.
+func TestMakefileHasBenchRegressionTarget(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("Makefile")
+	require.NoError(t, err, "Makefile must be readable from the repo root")
+
+	// Anchored regex: a line that begins with 'bench-regression:' at
+	// column 0 declares the target. The `.PHONY` directive on the
+	// preceding line is also required by project convention.
+	body := string(data)
+	assert.Regexp(t, regexp.MustCompile(`(?m)^\.PHONY:\s+bench-regression\b`), body,
+		"Makefile must declare 'bench-regression' as .PHONY")
+	assert.Regexp(t, regexp.MustCompile(`(?m)^bench-regression:`), body,
+		"Makefile must define a 'bench-regression' target")
+}

--- a/scripts/check-bench-regression.sh
+++ b/scripts/check-bench-regression.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# check-bench-regression.sh — parse a benchstat report and fail on regressions.
+#
+# Invoked by `make bench-regression` and by the benchstat-regression-guard CI
+# job. The input is benchstat's default human-readable report comparing
+# `bench.txt` (committed baseline) to `current.txt` (this run).
+#
+# Fail criteria (issue #17 AC):
+#   - Any `time/op` regression >= 10% at p <= 0.05
+#   - Any `allocs/op` regression > 0% (allocation increases are blocking
+#     regardless of statistical significance).
+#
+# Bytes-per-op is treated the same as time/op (10% + p<=0.05) since a bytes
+# increase without a commensurate allocs increase usually indicates a
+# structural change worth reviewing.
+#
+# Exit codes:
+#   0  no regressions above threshold
+#   1  one or more regressions found
+#   2  usage error (missing arg or file)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "usage: $0 <benchstat-report>" >&2
+	exit 2
+fi
+report="$1"
+if [[ ! -r "$report" ]]; then
+	echo "cannot read $report" >&2
+	exit 2
+fi
+
+threshold_pct=10
+alpha="0.05"
+
+violations=0
+current_section=""
+
+# benchstat (golang.org/x/perf/cmd/benchstat v0.0.0-20240730-ish) emits
+# three tables, each introduced by a TWO-line header that looks like:
+#
+#     │ old.txt │  new.txt            │
+#     │  sec/op │  sec/op    vs base  │
+#
+# The metric name lives on the second header line between box-drawing
+# pipes. We detect it and set the current section. Any subsequent line
+# with a "+X.XX%" delta is a regression candidate for that metric.
+#
+# Sections identified:
+#   sec/op     — time per op (threshold: >= 10% at p <= 0.05)
+#   B/op       — bytes per op (same threshold as time)
+#   allocs/op  — allocation count per op (ANY increase fails)
+
+while IFS= read -r line; do
+	if [[ "$line" =~ [[:space:]](sec/op|B/op|allocs/op)[[:space:]] ]]; then
+		current_section="${BASH_REMATCH[1]}"
+		continue
+	fi
+
+	# Data line with a positive (regression) delta: "+X.XX%".
+	if [[ "$line" =~ [+]([0-9]+)\.[0-9]+% ]]; then
+		pct="${BASH_REMATCH[1]}"
+
+		# Extract the p-value. benchstat emits "(p=0.XXX ...)" when both
+		# sides have at least 4 samples and the difference is significant;
+		# missing p values are treated as p=1 (not significant).
+		p="1"
+		if [[ "$line" =~ p=([0-9]+\.[0-9]+) ]]; then
+			p="${BASH_REMATCH[1]}"
+		fi
+
+		flag_regression=0
+		case "$current_section" in
+			sec/op|B/op)
+				if (( pct >= threshold_pct )) && awk -v p="$p" -v a="$alpha" 'BEGIN {exit !(p+0 <= a+0)}'; then
+					flag_regression=1
+				fi
+				;;
+			allocs/op)
+				# Any measurable allocs/op increase is a regression.
+				flag_regression=1
+				;;
+		esac
+
+		if (( flag_regression == 1 )); then
+			echo "::error::regression ($current_section): $line"
+			violations=$((violations + 1))
+		fi
+	fi
+done < "$report"
+
+if (( violations > 0 )); then
+	echo "benchstat found $violations regression(s) above threshold (time/op >=${threshold_pct}% at p<=${alpha}, or any allocs/op increase)" >&2
+	exit 1
+fi
+echo "No regressions above threshold."


### PR DESCRIPTION
## Summary

Issue #17 asks for a CI guard that fails PRs regressing the committed `bench.txt` baseline. Delivers:

- **New job `benchstat-regression-guard`** in `.github/workflows/ci.yml`. Pins `benchstat` (via `go install golang.org/x/perf/cmd/benchstat@<sha>`), runs `make bench-regression`, and uploads the benchstat report as a job artefact for reviewers.
- **Threshold script** `scripts/check-bench-regression.sh` parses benchstat's output (modern box-drawing table format) and enforces:
  - any `sec/op` regression **≥ 10%** at **p ≤ 0.05** fails the build
  - any `allocs/op` increase fails the build (regardless of significance)
  - `B/op` uses the same threshold as `sec/op`
- **`make bench-regression`** target mirrors what CI runs so developers can check locally: `go test -bench=. -benchmem -run=^$ -count=5`, then `benchstat bench.txt current.txt`, then the threshold script.
- **`TestMakefileHasBenchRegressionTarget`** text-asserts the target exists; defends against accidental deletion.
- **`CONTRIBUTING.md`** gains a Performance baseline subsection — thresholds, local run, baseline regeneration, and how to read a benchstat report.
- **Dependabot PRs are skipped** — dependency bumps cannot legitimately move in-tree benchmarks, so variance there is noise.

Drive-by: flattened the README collapsible TOC to a plain bullet list per preference.

Closes #17.

## Test plan

- [x] `make check` — coverage 97.9%+, lint clean, race-clean, govulncheck clean
- [x] Locally ran `make bench-regression` against current tree: "No regressions above threshold." ✓
- [x] Synthetic regression test (fake `bench.txt` vs `current.txt` with +30% sec/op and 2× allocs): script exits 1 and reports both regressions ✓
- [x] Positive control (5% sec/op, below threshold): script exits 0 ✓
- [x] `make help` — `bench-regression` present; Makefile-targets guard list updated
- [ ] CI green on push