### PR TITLE
chore(governance): tidy issue templates, enable Discussions + security features, record CLA #1

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,3 @@ contact_links:
   - name: "💬 Questions and discussions"
     url: https://github.com/axonops/mask/discussions
     about: Ask questions, share ideas, or discuss usage in GitHub Discussions.
-  - name: "🔐 Security vulnerabilities"
-    url: https://github.com/axonops/mask/blob/main/SECURITY.md
-    about: Report security vulnerabilities privately via the SECURITY.md process — do NOT open a public issue.
-  - name: "📜 Code of Conduct"
-    url: https://github.com/axonops/mask/blob/main/CODE_OF_CONDUCT.md
-    about: Review the community standards before interacting in issues or pull requests.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -46,12 +46,10 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/axonops/mask/blob/main/CLA.md"
           branch: "main"
-          # Allowlisted accounts do not need to sign the CLA:
-          #   - millerjp           — project owner (already signs by owning it)
-          #   - dependabot[bot]    — GitHub Dependabot
-          #   - renovate[bot]      — if/when Renovate is added
-          #   - github-actions[bot]— GitHub Actions identity
-          allowlist: "millerjp,dependabot[bot],renovate[bot],github-actions[bot]"
+          # Allowlisted accounts do not need to sign the CLA. Bots only —
+          # humans always go through the check so they are recorded in
+          # the signatures file and the public CONTRIBUTORS.md list.
+          allowlist: "dependabot[bot],renovate[bot],github-actions[bot]"
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, you need to sign our [Contributor License Agreement](https://github.com/axonops/mask/blob/main/CLA.md).
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,4 +7,12 @@ Agreement](./CLA.md) and contributed to `github.com/axonops/mask`.
 > by `.github/workflows/contributors.yml` every time a new signature
 > lands. Do not edit it by hand — edits are overwritten.
 
-_No contributors have signed yet. Be the first — open a pull request._
+## Signatories
+
+| Contributor | GitHub | Signed (UTC) | First PR |
+|---|---|---|---|
+| Johnny Miller | [@millerjp](https://github.com/millerjp) | 2026-04-19 | [#40](https://github.com/axonops/mask/pull/40) |
+
+---
+
+_1 contributor so far. Full signature records live in [`signatures/version1/cla.json`](./signatures/version1/cla.json)._

--- a/governance_test.go
+++ b/governance_test.go
@@ -90,9 +90,13 @@ func TestGovernance_CLAWorkflowExists(t *testing.T) {
 	// through the `main` branch protection.
 	assert.Contains(t, s, "CLA_ASSISTANT_PAT",
 		"CLA workflow must reference the CLA_ASSISTANT_PAT secret for the bot push")
-	// Allowlist must include the project owner and the expected bots.
-	assert.Contains(t, s, "millerjp")
+	// Allowlist must cover the automation bots that cannot sign via PR
+	// comment. Humans (including the project owner) are deliberately NOT
+	// allowlisted — they go through the signing flow once and are then
+	// recorded in signatures/version1/cla.json.
 	assert.Contains(t, s, "dependabot[bot]")
+	assert.Contains(t, s, "renovate[bot]")
+	assert.Contains(t, s, "github-actions[bot]")
 }
 
 func TestGovernance_ContributorsWorkflowExists(t *testing.T) {

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,0 +1,13 @@
+{
+  "signedContributors": [
+    {
+      "name": "Johnny Miller",
+      "id": 163300,
+      "comment_id": 0,
+      "created_at": "2026-04-19T07:25:00Z",
+      "repoId": 0,
+      "pullRequestNo": 40,
+      "login": "millerjp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #40 addressing your review of the issue-template list, plus the bootstrap problem for the first CLA signature.

**1. Issue-template config slimmed.** `config.yml` now keeps only the Discussions link:

- **Dropped** the "Security vulnerabilities" contact link — with Private Vulnerability Reporting enabled on the repo, GitHub now surfaces a native "Report a security vulnerability" item on the new-issue dialog automatically. The manual link duplicated it.
- **Dropped** the "Code of Conduct" contact link — CoC is already linked from `CONTRIBUTING.md`, the PR template, and the README. An extra slot on the new-issue screen earned no value.

**2. Repo security and Discussions turned on via `gh api`** (not a file change, but flagged here so the change is auditable):

| Setting | Before | After |
|---|---|---|
| Discussions | off | **on** |
| Secret scanning | off | **on** |
| Secret scanning push protection | off | **on** |
| Dependabot security updates | off | **on** |
| Private vulnerability reporting | off | **on** |

**3. CLA signature #1 handcrafted.** You opted out of going through the bot on your own first PR. `signatures/version1/cla.json` is created with a `signedContributors` entry matching the schema the CLA Assistant uses, citing PR #40 as the first contribution. `CONTRIBUTORS.md` regenerated from the JSON now shows one row.

**4. CLA allowlist narrowed to bots only.** Removed `millerjp` from the allowlist. Your future PRs still pass the CLA check (you're in the JSON); anyone else signs via the bot.

## Test plan

- [x] `make check` — race-clean, lint clean, govulncheck clean, 97.9%+ coverage
- [x] Governance tests updated (allowlist now asserts the bot list, not `millerjp`) — pass
- [x] `scripts/generate-contributors.sh` produces `CONTRIBUTORS.md` with one row
- [x] Markdownlint clean on every doc
- [ ] CI green on push