### PR TITLE
fix(contributors): bootstrap signature has no backing PR

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,7 +11,7 @@ Agreement](./CLA.md) and contributed to `github.com/axonops/mask`.
 
 | Contributor | GitHub | Signed (UTC) | First PR |
 |---|---|---|---|
-| Johnny Miller | [@millerjp](https://github.com/millerjp) | 2026-04-19 | [#40](https://github.com/axonops/mask/pull/40) |
+| Johnny Miller | [@millerjp](https://github.com/millerjp) | 2026-04-19 | — |
 
 ---
 

--- a/scripts/generate-contributors.sh
+++ b/scripts/generate-contributors.sh
@@ -79,7 +79,9 @@ HEADER
 	echo "|---|---|---|---|"
 
 	# Sort by signed_at so the table has a stable, meaningful order
-	# (oldest first). Unknown timestamps sort last.
+	# (oldest first). A pullRequestNo of 0 means "handcrafted / bootstrap
+	# signature" (no real PR to link) — rendered as an em-dash rather
+	# than a dead link.
 	echo "$entries" | jq -r '
 		map({
 			name: (.name // .login // "unknown"),
@@ -90,7 +92,9 @@ HEADER
 		})
 		| sort_by(.signed)
 		| .[]
-		| "| \(.name) | [@\(.login)](https://github.com/\(.login)) | \(.signed[:10]) | [#\(.pr)](https://github.com/axonops/mask/pull/\(.pr)) |"
+		| "| \(.name) | [@\(.login)](https://github.com/\(.login)) | \(.signed[:10]) | " +
+		  (if .pr == 0 then "—" else "[#\(.pr)](https://github.com/axonops/mask/pull/\(.pr))" end) +
+		  " |"
 	'
 
 	echo

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -6,7 +6,7 @@
       "comment_id": 0,
       "created_at": "2026-04-19T07:25:00Z",
       "repoId": 0,
-      "pullRequestNo": 40,
+      "pullRequestNo": 0,
       "login": "millerjp"
     }
   ]


### PR DESCRIPTION
Small fix after review.

The handcrafted signature in \`signatures/version1/cla.json\` cited PR #40, which was where the CLA bot itself was introduced — not my first real contribution to this repo. Reset \`pullRequestNo\` to 0 and tweak the generator so handcrafted bootstrap signatures render an em-dash in the "First PR" column instead of linking to a non-existent PR.

Future bot-recorded signatures always carry a real PR number, so the dash only ever appears for handcrafted entries.