### PR TITLE
docs: use make target for llms-full regeneration (#43)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Branch-name prefixes used in this project: `feature/`, `fix/`, `docs/`, `chore/`
 - Follow the [Ground rules](#ground-rules), [Commits](#commits), [Pull requests](#pull-requests), [Testing](#testing), and [Code standards](#code-standards) sections below.
 - Add unit tests AND BDD scenarios for any new or changed masking rule.
 - Run `make check` until it is clean before pushing.
-- If your change edits any of the files bundled into `llms-full.txt` (documentation, examples, `README.md`, `CONTRIBUTING.md`, etc.), also regenerate it with `./scripts/gen-llms-full.sh` and commit the refreshed `llms-full.txt` in the same commit — CI enforces this.
+- If your change edits any of the files bundled into `llms-full.txt` (documentation, examples, `README.md`, `CONTRIBUTING.md`, etc.), also regenerate it with `make llms-full` and commit the refreshed `llms-full.txt` in the same commit — CI enforces this via `make llms-full-check`.
 
 ### 5. Commit (signed, conventional-commit message)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -761,7 +761,7 @@ Branch-name prefixes used in this project: `feature/`, `fix/`, `docs/`, `chore/`
 - Follow the [Ground rules](#ground-rules), [Commits](#commits), [Pull requests](#pull-requests), [Testing](#testing), and [Code standards](#code-standards) sections below.
 - Add unit tests AND BDD scenarios for any new or changed masking rule.
 - Run `make check` until it is clean before pushing.
-- If your change edits any of the files bundled into `llms-full.txt` (documentation, examples, `README.md`, `CONTRIBUTING.md`, etc.), also regenerate it with `./scripts/gen-llms-full.sh` and commit the refreshed `llms-full.txt` in the same commit — CI enforces this.
+- If your change edits any of the files bundled into `llms-full.txt` (documentation, examples, `README.md`, `CONTRIBUTING.md`, etc.), also regenerate it with `make llms-full` and commit the refreshed `llms-full.txt` in the same commit — CI enforces this via `make llms-full-check`.
 
 ### 5. Commit (signed, conventional-commit message)
 


### PR DESCRIPTION
## Summary

Tiny follow-up to #44. The first-PR walkthrough step 4 instructed contributors to run `./scripts/gen-llms-full.sh` directly; the project convention is to go through the Makefile. Switches to `make llms-full` and points at `make llms-full-check` as the CI enforcement surface so contributors see a single consistent interface.

Re-refs #43.

## Test plan

- [x] `make llms-full` regenerates `llms-full.txt` cleanly.
- [x] `make llms-full-check` passes.
- [x] `markdownlint-cli2 CONTRIBUTING.md` clean.
- [ ] CI green on this PR.