### PR TITLE
chore(release): prepare v1.0.0 as the initial stable release (#46)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g. v0.9.0). Must not exist yet; workflow creates it."
+        description: "Tag to release (e.g. v1.0.0). Must not exist yet; workflow creates it."
         required: true
         type: string
       dry_run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,15 @@ No unreleased changes.
 
 ## Upgrading
 
-While the project is pre-1.0 (`v0.x`) every minor version MAY include
-breaking changes. Pin a specific tag in `go.mod` and treat every minor
-bump as a manual review step: read the release notes for the target
-version, update your `Register` / `DeterministicHashFunc` call sites
-where the public API has changed, run your test suite with
-`-race`, and confirm the new version against the `make check` gate
-before rolling to production. From `v1.0.0` onwards the library
-commits to the standard Go semver compatibility promise — breaking
-changes only in a new major version.
+From `v1.0.0` onwards `mask` follows the standard Go semantic-versioning
+compatibility promise: breaking changes to the public API only in a new
+major version. Minor and patch releases are always backwards-compatible
+for the API surface documented on [pkg.go.dev](https://pkg.go.dev/github.com/axonops/mask).
+Pin a specific tag in your `go.mod`, review the release notes for the
+target version, and run your test suite with `-race` against the new
+version before rolling to production.
 
-## [0.9.0] — 2026-04-18
+## [1.0.0] — 2026-04-19
 
 Initial public release.
 
@@ -39,5 +37,5 @@ Initial public release.
 - **CI/CD.** Format check, vet, lint, unit and BDD tests, coverage, module tidy, security scan, cross-platform builds (`linux/amd64`, `darwin/arm64`, `windows/amd64`), and a CI-only release workflow — no local tagging permitted.
 - `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (Apache 2.0).
 
-[Unreleased]: https://github.com/axonops/mask/compare/v0.9.0...HEAD
-[0.9.0]: https://github.com/axonops/mask/releases/tag/v0.9.0
+[Unreleased]: https://github.com/axonops/mask/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/axonops/mask/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@
 
 ---
 
-## ⚠ Status
+## ✅ Status
 
-`mask` is pre-release software (`v0.x`). The public API may change between minor versions until `v1.0.0`. Pin the exact version in your `go.mod` and review the [CHANGELOG](./CHANGELOG.md) before upgrading.
+`mask` is **stable** from `v1.0.0` onwards and follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html): breaking changes to the public API only in a new major version. Pin a specific tag in your `go.mod` and review the [CHANGELOG](./CHANGELOG.md) on every upgrade.
 
 ## 🔍 Overview
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,13 @@
 
 ## Supported versions
 
-The `mask` library follows a `v0.x` versioning scheme. Only the most recent `v0.x` minor release receives security fixes until `v1.0.0` stabilises the API.
+The `mask` library follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Security fixes land on the most recent minor release of the current major version. Older majors (once a `v2.0.0` exists) are not supported.
 
 | Version | Supported |
 |---------|-----------|
-| `v0.9.x` | Yes |
-| Older | No |
+| `v1.x` (latest minor) | Yes |
+| Older `v1.x` minors | No |
+| Pre-1.0 (`v0.x`) | Never released |
 
 ## Threat model
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -204,9 +204,9 @@ Full catalogue: runtime via `mask.Rules()` and `mask.Describe(name)`; static ref
 
 ---
 
-## ⚠ Status
+## ✅ Status
 
-`mask` is pre-release software (`v0.x`). The public API may change between minor versions until `v1.0.0`. Pin the exact version in your `go.mod` and review the [CHANGELOG](./CHANGELOG.md) before upgrading.
+`mask` is **stable** from `v1.0.0` onwards and follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html): breaking changes to the public API only in a new major version. Pin a specific tag in your `go.mod` and review the [CHANGELOG](./CHANGELOG.md) on every upgrade.
 
 ## 🔍 Overview
 
@@ -1002,12 +1002,13 @@ By contributing, you agree that your contributions will be licensed under the [A
 
 ## Supported versions
 
-The `mask` library follows a `v0.x` versioning scheme. Only the most recent `v0.x` minor release receives security fixes until `v1.0.0` stabilises the API.
+The `mask` library follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Security fixes land on the most recent minor release of the current major version. Older majors (once a `v2.0.0` exists) are not supported.
 
 | Version | Supported |
 |---------|-----------|
-| `v0.9.x` | Yes |
-| Older | No |
+| `v1.x` (latest minor) | Yes |
+| Older `v1.x` minors | No |
+| Pre-1.0 (`v0.x`) | Never released |
 
 ## Threat model
 

--- a/rules_telecom.go
+++ b/rules_telecom.go
@@ -48,9 +48,9 @@ const (
 // msisdnKeepFirst / msisdnKeepLast are the preserved window counts
 // on MSISDN. The spec example uses a 2-digit country code (UK 44);
 // country codes can be 1-3 digits but a strict lookup table is out
-// of scope for v0.9.0. Operators needing strict per-country
-// handling should route such fields through `phone_number` in
-// E.164 form instead.
+// of scope for the initial release. Operators needing strict
+// per-country handling should route such fields through
+// `phone_number` in E.164 form instead.
 const (
 	// msisdnMinLen and msisdnMaxLen are inclusive bounds; inputs
 	// outside this range fail closed to SameLengthMask.


### PR DESCRIPTION
## Summary

- Skips the planned `v0.9.0` tag (used only as a dry-run) and cuts `v1.0.0` as the project's initial stable public release.
- Rewrites all pre-v1 caveats across `CHANGELOG.md`, `README.md`, `SECURITY.md`, `rules_telecom.go`, and `.github/workflows/release.yml`.
- Regenerates `llms-full.txt`.

Closes #46.

## Test plan

- [x] `make check` clean locally (98.1% coverage, 0 vulnerabilities).
- [x] `markdownlint-cli2` clean on README, CHANGELOG, SECURITY.
- [x] v0.9.0 release-workflow dry-run on `main` succeeded — pipeline validated.
- [ ] CI green on this PR.
- [ ] Release workflow dispatched with `tag=v1.0.0, dry_run=false` after merge.
- [ ] `v1.0.0` appears on pkg.go.dev and in the GitHub Releases tab flagged as **Latest**.

## Contribution checklist

- [x] My commits are cryptographically signed.
- [x] Conventional-commit format with issue reference.
- [x] CLA previously signed.