### PR TITLE
ci: add OpenSSF Scorecard weekly workflow and README badge (#52)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,85 @@
+name: Scorecard supply-chain security
+
+# OSSF Scorecard analysis. Runs weekly and on every push to main / PR
+# against main. Produces a SARIF report uploaded to GitHub Code
+# Scanning AND publishes the result to scorecard.dev so the README
+# badge and viewer at
+#   https://scorecard.dev/viewer/?uri=github.com/axonops/mask
+# stay current.
+#
+# Action pinning: ossf/scorecard-action MUST be pinned by 40-hex
+# commit SHA because Scorecard's own Pinned-Dependencies check
+# downgrades any action pinned by a mutable ref. Do NOT "normalise"
+# that pin to a semver tag — it degrades the very score we publish.
+# The other actions use the same semver-tag convention as ci.yml so
+# Dependabot's existing grouping covers them.
+
+on:
+  push:
+    branches: [main]
+    # Mirror ci.yml: the CLA Assistant pushes signatures/... directly
+    # to main and the contributors regenerator pushes CONTRIBUTORS.md.
+    # Neither can affect supply-chain posture; main-branch Scorecard
+    # must skip them so bot pushes don't retrigger the scan.
+    paths-ignore:
+      - "signatures/**"
+      - "CONTRIBUTORS.md"
+  pull_request:
+    branches: [main]
+  schedule:
+    # Saturdays at 01:30 UTC — matches the upstream OSSF template.
+    - cron: "30 1 * * 6"
+  workflow_dispatch: {}
+
+concurrency:
+  group: scorecard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Workflow-level least privilege; the analysis job below elevates
+# only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # SARIF upload to Code Scanning.
+      security-events: write
+      # OIDC token required when publish_results: true so the result
+      # can be signed and posted to api.scorecard.dev.
+      id-token: write
+      # Read the repository contents during analysis.
+      contents: read
+      # List workflow runs and metadata for the Token-Permissions and
+      # Pinned-Dependencies checks.
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to scorecard.dev so the public viewer and
+          # README badge stay current. Requires id-token: write above.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4.35.4
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- OpenSSF Scorecard weekly workflow (`.github/workflows/scorecard.yml`) that publishes a supply-chain posture score to `scorecard.dev` and uploads SARIF results to the GitHub Code scanning Security tab. Triggers on push to `main`, every PR against `main`, a weekly cron (Saturday 01:30 UTC), and `workflow_dispatch` for manual verification. Governance test `TestGovernance_ScorecardWorkflowExists` asserts the workflow's permission scopes, SHA-pinned action ref, `publish_results: true`, and `paths-ignore` policy. ([#52](https://github.com/axonops/mask/issues/52))
+- OpenSSF Scorecard badge in the README badge row (linking to the live viewer), and an Elsewhere link to the Scorecard report in `docs/README.md`. ([#52](https://github.com/axonops/mask/issues/52))
+
 ### Fixed
 
 - `phone_number` and `mobile_phone_number` now recognise the ITU-T `00<CC>` international access prefix in addition to `+<CC>`. Inputs like `0044 7911 123456` mask to `0044 **** **3456` (country code preserved, subscriber masked) instead of failing closed. The `00` prefix is kept verbatim — it is not rewritten to `+`. Inputs with a single domestic leading `0` (e.g. `07911 123456`) are unaffected. ([#55](https://github.com/axonops/mask/issues/55))

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   **String Masking for Go Services — PII, PCI, PHI, zero dependencies**
 
   [![CI](https://github.com/axonops/mask/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/axonops/mask/actions/workflows/ci.yml)
+  [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/axonops/mask/badge)](https://scorecard.dev/viewer/?uri=github.com/axonops/mask)
   [![Go Reference](https://pkg.go.dev/badge/github.com/axonops/mask.svg)](https://pkg.go.dev/github.com/axonops/mask)
   [![Go Report Card](https://goreportcard.com/badge/github.com/axonops/mask)](https://goreportcard.com/report/github.com/axonops/mask)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Deep-dive documentation for `github.com/axonops/mask`. The project [README](../R
 ## Elsewhere
 
 - [pkg.go.dev/github.com/axonops/mask](https://pkg.go.dev/github.com/axonops/mask) — generated Go API reference.
+- [OpenSSF Scorecard report](https://scorecard.dev/viewer/?uri=github.com/axonops/mask) — automated supply-chain security score, refreshed weekly.
 - [`../llms.txt`](../llms.txt) and [`../llms-full.txt`](../llms-full.txt) — AI-assistant-oriented documentation bundle.
 - [`../SECURITY.md`](../SECURITY.md) — threat model and coordinated disclosure.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — how to contribute.

--- a/governance_test.go
+++ b/governance_test.go
@@ -226,3 +226,57 @@ func TestGovernance_IssueTemplatesExist(t *testing.T) {
 		assert.NoError(t, err, "%s must exist", path)
 	}
 }
+
+func TestGovernance_ScorecardWorkflowExists(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile(".github/workflows/scorecard.yml")
+	require.NoError(t, err, ".github/workflows/scorecard.yml must exist")
+
+	var v any
+	require.NoError(t, yaml.Unmarshal(body, &v), "scorecard.yml must be valid YAML")
+
+	s := string(body)
+
+	// Least-privilege permission scopes required by Scorecard. SARIF
+	// upload needs security-events:write; publish_results requires
+	// the OIDC token (id-token:write); the Token-Permissions and
+	// Pinned-Dependencies checks need actions:read; the analysis
+	// itself needs contents:read.
+	for _, scope := range []string{
+		"security-events: write",
+		"id-token: write",
+		"actions: read",
+	} {
+		assert.Contains(t, s, scope,
+			"scorecard.yml must declare permission scope %q", scope)
+	}
+
+	// `contents: read` must appear at BOTH the workflow level (default
+	// least-privilege baseline) AND the job level (GitHub replaces,
+	// not merges, when a job overrides permissions). A bare Contains
+	// check would pass if only one of the two were present.
+	assert.GreaterOrEqualf(t,
+		strings.Count(s, "contents: read"), 2,
+		"scorecard.yml must declare `contents: read` at workflow AND job level")
+
+	// The Scorecard action MUST be pinned by 40-hex commit SHA, not a
+	// mutable tag — Scorecard's own Pinned-Dependencies check
+	// downgrades the score otherwise. The equivalent semver tag
+	// travels in a trailing comment for human readability.
+	assert.Regexp(t, `ossf/scorecard-action@[0-9a-f]{40}`, s,
+		"ossf/scorecard-action must be pinned by full 40-hex commit SHA")
+
+	// publish_results: true is what posts the score to scorecard.dev
+	// so the README badge stays live. Disabling it silently breaks
+	// the public viewer.
+	assert.Contains(t, s, "publish_results: true",
+		"scorecard.yml must publish results to scorecard.dev")
+
+	// Mirror ci.yml: bot pushes that only touch signatures or the
+	// generated contributors list must not retrigger the scan.
+	// Regex form tolerates quoted, single-quoted, or bare-scalar YAML.
+	assert.Regexp(t, `(?s)paths-ignore:.*signatures/\*\*`, s,
+		"scorecard.yml must paths-ignore signatures/**")
+	assert.Regexp(t, `(?s)paths-ignore:.*CONTRIBUTORS\.md`, s,
+		"scorecard.yml must paths-ignore CONTRIBUTORS.md")
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -175,6 +175,7 @@ Full catalogue: runtime via `mask.Rules()` and `mask.Describe(name)`; static ref
   **String Masking for Go Services — PII, PCI, PHI, zero dependencies**
 
   [![CI](https://github.com/axonops/mask/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/axonops/mask/actions/workflows/ci.yml)
+  [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/axonops/mask/badge)](https://scorecard.dev/viewer/?uri=github.com/axonops/mask)
   [![Go Reference](https://pkg.go.dev/badge/github.com/axonops/mask.svg)](https://pkg.go.dev/github.com/axonops/mask)
   [![Go Report Card](https://goreportcard.com/badge/github.com/axonops/mask)](https://goreportcard.com/report/github.com/axonops/mask)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)


### PR DESCRIPTION
## Summary

- Closes #52.
- Adds `.github/workflows/scorecard.yml` — OpenSSF Scorecard runs weekly (Sat 01:30 UTC), on push to `main`, on every PR against `main`, and via `workflow_dispatch` for manual verification.
- Publishes results to `scorecard.dev` (`publish_results: true`) AND uploads SARIF to GitHub Code scanning Security tab.
- New OpenSSF Scorecard badge in the README badge row (between CI and Go Reference), plus an Elsewhere link in `docs/README.md`.
- New governance test `TestGovernance_ScorecardWorkflowExists` asserts permission scopes, SHA-pinned action ref, `publish_results: true`, and `paths-ignore` policy.

## Pinning policy

`ossf/scorecard-action` is pinned by 40-hex commit SHA (currently `4eaacf0…` = v2.4.3) because Scorecard's own `Pinned-Dependencies` check downgrades any action pinned by mutable ref. The other three actions stay on semver tags (`@v6.0.2`, `@v7.0.1`, `@v4.35.4`) to match the convention in `ci.yml` and keep Dependabot's existing grouping intact.

## Permission scoping

Workflow-level baseline: `contents: read`. The analysis job elevates to `security-events: write` (SARIF upload), `id-token: write` (OIDC for `publish_results`), `actions: read` (Token-Permissions + Pinned-Dependencies checks), and re-declares `contents: read` because GitHub replaces — not merges — workflow-level permissions when a job overrides them.

## Test plan

- [x] `make check` clean locally (fmt, vet, lint=0 issues, tidy, race tests, BDD, coverage 98.1%, govulncheck).
- [x] `make llms-full-check` clean.
- [x] `TestGovernance_ScorecardWorkflowExists` passes.
- [x] `actionlint` clean on the new workflow file.
- [x] YAML parses cleanly (`python3 yaml.safe_load`).
- [ ] **Post-merge**: trigger `workflow_dispatch` from the Actions UI on `main` to satisfy AC #2 immediately; verify SARIF appears under Security → Code scanning.
- [ ] **Post-merge ≤24h**: confirm `https://scorecard.dev/viewer/?uri=github.com/axonops/mask` returns a live score (AC #3). The issue's own caveat notes scorecard.dev may lag the first run by up to 24h.

## Notes for reviewers

- This PR's own `pull_request` event will trigger the new workflow as its first live run — that satisfies AC #2 before merge.
- The badge URL (`api.scorecard.dev/projects/github.com/axonops/mask/badge`) renders a grey "unavailable" placeholder until the first published run lands; it auto-updates from then on.