### PR TITLE
ci: tighten workflow token permissions to least privilege (#66)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,19 +6,24 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-# Explicit permissions because repository-level workflow permissions
-# may be read-only. The PAT below carries the actual push authority
-# through branch protection; GITHUB_TOKEN is used for PR comments and
-# status updates.
+# Workflow-level least-privilege baseline. The CLAAssistant job below
+# elevates only the scopes contributor-assistant/github-action actually
+# uses: contents (commit signature file), pull-requests (post the
+# not-signed / all-signed / lock-after-merge comments), and statuses
+# (set the CLA status check that branch protection consumes). The
+# CLA_ASSISTANT_PAT secret remains the actual push authority through
+# branch protection on main; GITHUB_TOKEN's scopes cover only the
+# read/comment/status surface.
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
     # Skip unless the trigger is either a relevant PR event or a comment
     # that looks like a signature / recheck request. The action filter
     # inside the step duplicates this; having it at the job level avoids

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -10,13 +10,22 @@ on:
 # that pushed the signature is skipped via [skip ci] conventions
 # elsewhere, but this workflow only triggers on the signatures path
 # so unrelated main-branch pushes do not spin up this runner.
+#
+# Workflow-level least-privilege baseline. The regenerate job below
+# elevates `contents: write` to remain forward-compatible if the
+# CLA_ASSISTANT_PAT secret is ever removed in favour of GITHUB_TOKEN-
+# based pushes — the PAT carries the actual push authority today
+# (both fetch and push via actions/checkout's `token:` input), so
+# GITHUB_TOKEN's `contents:` scope is effectively unused.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   regenerate:
     name: Regenerate CONTRIBUTORS.md
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,15 +4,21 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Workflow-level least-privilege baseline. The automerge job below
+# elevates the two scopes `gh pr merge --auto --squash` requires:
+# pull-requests (to enable the auto-merge state) and contents (the
+# eventual squash commit fires once required checks pass).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
     name: Enable auto-merge for patch-level test-dependency updates
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Inspect Dependabot metadata
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Workflow-level least-privilege baseline. Every job below declares
+# its own `permissions:` block so this baseline applies only as a
+# safety net for any future job added without an explicit override.
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify quality gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - `phone_number` and `mobile_phone_number` now recognise the ITU-T `00<CC>` international access prefix in addition to `+<CC>`. Inputs like `0044 7911 123456` mask to `0044 **** **3456` (country code preserved, subscriber masked) instead of failing closed. The `00` prefix is kept verbatim — it is not rewritten to `+`. Inputs with a single domestic leading `0` (e.g. `07911 123456`) are unaffected. ([#55](https://github.com/axonops/mask/issues/55))
 - Compact form (`00CC<digits>` with no separator between country code and subscriber) is accepted on the `00` path to match the dial-string convention. The `+` parser continues to require a separator after the country code; this asymmetry is deliberate and documented in the rule godoc. ([#55](https://github.com/axonops/mask/issues/55))
 
+### Security
+
+- Tightened workflow token permissions to a `contents: read` workflow-level baseline across `cla.yml`, `contributors.yml`, `dependabot-automerge.yml`, and `release.yml`. Jobs that need elevated scopes (`contents: write`, `pull-requests: write`, `statuses: write`) now declare them per-job rather than workflow-wide, so a future job added to one of these workflows inherits read-only by default. Dropped the redundant `actions: write` scope from the CLA Assistant flow. Governance test `TestGovernance_WorkflowsLeastPrivilegeBaseline` pins the baseline (single `contents: read` key) across all six workflow files. ([#66](https://github.com/axonops/mask/issues/66))
+
 ## Upgrading
 
 From `v1.0.0` onwards `mask` follows the standard Go semantic-versioning

--- a/governance_test.go
+++ b/governance_test.go
@@ -280,3 +280,70 @@ func TestGovernance_ScorecardWorkflowExists(t *testing.T) {
 	assert.Regexp(t, `(?s)paths-ignore:.*CONTRIBUTORS\.md`, s,
 		"scorecard.yml must paths-ignore CONTRIBUTORS.md")
 }
+
+// TestGovernance_WorkflowsLeastPrivilegeBaseline asserts that every
+// workflow under .github/workflows/ declares a workflow-level
+// `permissions:` block containing exactly `contents: read`. Per-job
+// blocks may elevate further (GitHub replaces, not merges, when a job
+// overrides); this assertion only pins the workflow-level baseline so
+// any future job added without its own block inherits the least-
+// privilege default.
+//
+// The list of workflows is pinned here rather than discovered from
+// disk so adding a new workflow without a baseline is a forced test
+// failure rather than a silent omission. A glob cross-check below
+// catches the inverse mistake — adding a workflow file but forgetting
+// to register it in this list.
+func TestGovernance_WorkflowsLeastPrivilegeBaseline(t *testing.T) {
+	t.Parallel()
+	pinned := []string{
+		".github/workflows/ci.yml",
+		".github/workflows/cla.yml",
+		".github/workflows/contributors.yml",
+		".github/workflows/dependabot-automerge.yml",
+		".github/workflows/release.yml",
+		".github/workflows/scorecard.yml",
+	}
+
+	// Cross-check: every workflow on disk must be in the pinned list.
+	// Adding a new workflow file without registering it here would
+	// otherwise let the new workflow ship without a least-privilege
+	// audit.
+	onDisk, err := filepath.Glob(".github/workflows/*.yml")
+	require.NoError(t, err, "filepath.Glob must succeed")
+	require.ElementsMatch(t, pinned, onDisk,
+		"every .github/workflows/*.yml file must be registered in this test's pinned list")
+
+	for _, path := range pinned {
+		body, err := os.ReadFile(path)
+		require.NoErrorf(t, err, "%s must exist", path)
+
+		// String-form assertion: `contents: read` appears at the top
+		// level. The regex anchors `permissions:` at column zero so it
+		// cannot accidentally match a job-scoped block (which is always
+		// indented), and tolerates intervening YAML comment lines.
+		s := string(body)
+		assert.Regexpf(t,
+			`(?m)^permissions:\s*(?:\n[ \t]+#[^\n]*)*\n[ \t]+contents:\s*read\b`,
+			s,
+			"%s must declare workflow-level `permissions: contents: read`", path)
+
+		// Structural assertion: the workflow-level `permissions:`
+		// mapping contains exactly one key (`contents: read`). Any
+		// other top-level scope must move to a per-job block. This
+		// closes the loophole where adding `pull-requests: write` at
+		// workflow level alongside `contents: read` would still
+		// satisfy the string regex.
+		var doc map[string]any
+		require.NoErrorf(t, yaml.Unmarshal(body, &doc), "%s must be valid YAML", path)
+		perms, ok := doc["permissions"].(map[string]any)
+		require.Truef(t, ok, "%s must declare a workflow-level `permissions:` mapping", path)
+		assert.Lenf(t, perms, 1,
+			"%s workflow-level `permissions:` must contain exactly one key (`contents: read`); add elevated scopes per-job instead", path)
+		cv, ok := perms["contents"].(string)
+		require.Truef(t, ok,
+			"%s workflow-level `permissions:` must contain a string `contents` key", path)
+		assert.Equalf(t, "read", cv,
+			"%s workflow-level `permissions.contents` must be `read`", path)
+	}
+}


### PR DESCRIPTION
## Summary

- Tracks #66 — the issue stays open after this merge until the four post-merge observations (CLA signing, contributors push, Dependabot auto-merge, Scorecard `Token-Permissions` score ≥8) are ticked. See the "Post-merge verification (tracked, non-blocking)" section of #66.
- Adds workflow-level `permissions: contents: read` baseline to `cla.yml`, `contributors.yml`, `dependabot-automerge.yml`, and `release.yml` — the four workflows OpenSSF Scorecard's `Token-Permissions` check flagged as declaring write-level scopes at top level.
- Moves elevated scopes (`contents: write`, `pull-requests: write`, `statuses: write`) into per-job `permissions:` blocks so a future job added to one of these workflows inherits read-only by default.
- Dropped the redundant `actions: write` from the CLA Assistant flow — the action's source calls only `issues`, `statuses`, `repos`, and `pulls` endpoints; the Actions API scope was cargo-cult.
- `ci.yml` and `scorecard.yml` already follow the baseline pattern; the governance test pins the policy across all six workflow files.

## Expected Scorecard score uplift

`Token-Permissions` should move from **0/10 → ≥8/10** on the next scheduled scan (within ~24h of merge; the issue's own caveat notes scorecard.dev may lag).

## Governance test

`TestGovernance_WorkflowsLeastPrivilegeBaseline` enforces the policy with two layered assertions:

1. **Regex** anchored at column zero requiring `contents: read` at the workflow level (comment-tolerant for the YAML preamble we ship in cla.yml / contributors.yml / dependabot-automerge.yml / release.yml).
2. **YAML structural** check that the workflow-level `permissions:` mapping contains exactly one key (`contents: read`). Closes the loophole where a future PR could add `pull-requests: write` at workflow level alongside `contents: read` and still satisfy a plain string check.

Plus a **glob cross-check** that every `.github/workflows/*.yml` file on disk appears in the test's pinned list — so adding a new workflow without registering it is a forced test failure rather than a silent omission.

## Pre-merge verification (AC #6)

`release.yml workflow_dispatch` with `dry_run: true` on this branch: https://github.com/axonops/mask/actions/runs/25794924148 — conclusion **success**. Per-job: `verify` ✓, `goreleaser` ✓ (snapshot mode), `tag` and `proxy-warm` correctly skipped on dry-run. No permission errors anywhere in the logs.

## Known gap, scoped to #65

`cla.yml` still pins `contributor-assistant/github-action@v2.6.1` (a tag, not a 40-hex SHA). Combined with this workflow's `pull_request_target` trigger and the `CLA_ASSISTANT_PAT` admin token in the job env, that's a tag-retag supply-chain risk worth closing — but it belongs in **#65** (the upcoming repo-wide SHA-pinning sweep), not in this PR which is scoped to permission scopes only.

## Test plan

- [x] `make check` clean locally (fmt, vet, lint=0, tidy, race tests, BDD, coverage 98.1%, govulncheck).
- [x] `make llms-full-check` clean (no llms-full bundled file changed).
- [x] `TestGovernance_WorkflowsLeastPrivilegeBaseline` passes.
- [x] `TestGovernance_ScorecardWorkflowExists` still passes (no regression).
- [x] `actionlint` clean on the four edited workflows.
- [x] Release `workflow_dispatch` with `dry_run: true` succeeds without permission errors.
- [ ] **Post-merge tracked on #66 (non-blocking — issue stays open):**
  - CLA signing event pushes `signatures/version1/cla.json` successfully.
  - Contributors regenerator push to `CONTRIBUTORS.md` succeeds.
  - Dependabot auto-merge squash-merges a qualifying patch PR.
  - `scorecard.dev` shows `Token-Permissions` score ≥ 8 within ~24h of next scheduled scan.