### PR TITLE
feat(ci): auto-post release announcement to Discussions (#51)

### DIFF
--- a/.github/DISCUSSION_ANNOUNCEMENT_FOOTER.md
+++ b/.github/DISCUSSION_ANNOUNCEMENT_FOOTER.md
@@ -1,0 +1,9 @@
+## Install
+
+```sh
+go get github.com/axonops/mask@<tag>
+```
+
+Docs: [README](https://github.com/axonops/mask#readme) · [docs/rules.md](https://github.com/axonops/mask/blob/<tag>/docs/rules.md) · [docs/extending.md](https://github.com/axonops/mask/blob/<tag>/docs/extending.md) · [docs/hashing.md](https://github.com/axonops/mask/blob/<tag>/docs/hashing.md) · [pkg.go.dev/github.com/axonops/mask@<tag>](https://pkg.go.dev/github.com/axonops/mask@<tag>)
+
+Feedback: [Issues](https://github.com/axonops/mask/issues) · [Discussions](https://github.com/axonops/mask/discussions) · [SECURITY.md](https://github.com/axonops/mask/blob/<tag>/SECURITY.md)

--- a/.github/test-fixtures/release-payload-draft.json
+++ b/.github/test-fixtures/release-payload-draft.json
@@ -1,0 +1,11 @@
+{
+  "action": "published",
+  "release": {
+    "tag_name": "v1.0.2",
+    "name": "v1.0.2 draft",
+    "prerelease": false,
+    "draft": true,
+    "html_url": "https://github.com/axonops/mask/releases/tag/v1.0.2",
+    "body": "Draft body — do not announce."
+  }
+}

--- a/.github/test-fixtures/release-payload-prerelease.json
+++ b/.github/test-fixtures/release-payload-prerelease.json
@@ -1,0 +1,11 @@
+{
+  "action": "published",
+  "release": {
+    "tag_name": "v1.0.2-rc1",
+    "name": "v1.0.2-rc1",
+    "prerelease": true,
+    "draft": false,
+    "html_url": "https://github.com/axonops/mask/releases/tag/v1.0.2-rc1",
+    "body": "Pre-release smoke build — do not announce."
+  }
+}

--- a/.github/test-fixtures/release-payload-stable.json
+++ b/.github/test-fixtures/release-payload-stable.json
@@ -1,0 +1,11 @@
+{
+  "action": "published",
+  "release": {
+    "tag_name": "v1.0.2",
+    "name": "v1.0.2",
+    "prerelease": false,
+    "draft": false,
+    "html_url": "https://github.com/axonops/mask/releases/tag/v1.0.2",
+    "body": "### Added\n\n- Example addition for fixture coverage.\n\n### Fixed\n\n- Example fix for fixture coverage."
+  }
+}

--- a/.github/workflows/release-announcement.yml
+++ b/.github/workflows/release-announcement.yml
@@ -1,0 +1,106 @@
+name: Release announcement
+
+# Posts a GitHub Discussion in the Announcements category whenever a
+# stable release is published. Pre-releases and drafts are skipped.
+# The footer template at .github/DISCUSSION_ANNOUNCEMENT_FOOTER.md is
+# substituted with the release tag at run time so the install command
+# and pkg.go.dev link point at the version being announced. See #51
+# for design rationale.
+
+on:
+  release:
+    types: [published]
+
+# Workflow-level least-privilege baseline (single key). The
+# announce job below declares `discussions: write` per-job.
+permissions:
+  contents: read
+
+env:
+  # The Announcements category id. Workflow-level env var so a future
+  # category restructure is a one-line change rather than a search
+  # through a shell step. Re-discover via:
+  #   gh api graphql -f query='query { repository(owner: "axonops", name: "mask") { discussionCategories(first: 20) { nodes { id name } } } }'
+  ANNOUNCEMENTS_CATEGORY_ID: DIC_kwDOSFydIc4C7L1u
+
+jobs:
+  announce:
+    name: Post announcement
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      discussions: write
+    # Skip prereleases (semver -rc / -beta tags) and drafts.
+    # GoReleaser publishes with draft: false; the draft check here
+    # is defence-in-depth.
+    if: github.event.release.prerelease == false && github.event.release.draft == false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build announcement body
+        id: build-body
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          set -euo pipefail
+          footer=$(sed "s|<tag>|${TAG}|g" .github/DISCUSSION_ANNOUNCEMENT_FOOTER.md)
+          {
+            printf '**mask %s** is now available.\n\n' "$TAG"
+            printf 'GitHub release: %s\n\n' "$RELEASE_URL"
+            printf '%s\n\n---\n\n%s\n' "$RELEASE_BODY" "$footer"
+          } > body.md
+          # Sanity-check the version pinning required by AC9 of #51.
+          if ! grep -q "go get github.com/axonops/mask@${TAG}" body.md; then
+            echo "::error::footer did not substitute <tag> into the install command"
+            exit 1
+          fi
+          if ! grep -q "pkg.go.dev/github.com/axonops/mask@${TAG}" body.md; then
+            echo "::error::footer did not substitute <tag> into the pkg.go.dev link"
+            exit 1
+          fi
+          if grep -q '@latest' body.md; then
+            echo "::error::body contains @latest — announcements must be version-pinned"
+            exit 1
+          fi
+          echo "body-file=body.md" >> "$GITHUB_OUTPUT"
+          echo "title=mask ${TAG} is released" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve repository node id
+        id: repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          repo_id=$(gh api graphql -f query='query { repository(owner: "axonops", name: "mask") { id } }' --jq '.data.repository.id')
+          if [ -z "$repo_id" ]; then
+            echo "::error::could not resolve repository node id"
+            exit 1
+          fi
+          echo "id=${repo_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Post discussion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_ID: ${{ steps.repo.outputs.id }}
+          CATEGORY_ID: ${{ env.ANNOUNCEMENTS_CATEGORY_ID }}
+          TITLE: ${{ steps.build-body.outputs.title }}
+        run: |
+          set -euo pipefail
+          body=$(cat body.md)
+          url=$(gh api graphql \
+            -f query='mutation($repo: ID!, $cat: ID!, $title: String!, $body: String!) { createDiscussion(input: {repositoryId: $repo, categoryId: $cat, title: $title, body: $body}) { discussion { url } } }' \
+            -F repo="$REPO_ID" \
+            -F cat="$CATEGORY_ID" \
+            -F title="$TITLE" \
+            -F body="$body" \
+            --jq '.data.createDiscussion.discussion.url')
+          if [ -z "$url" ]; then
+            echo "::error::createDiscussion returned no url — mutation likely failed"
+            exit 1
+          fi
+          echo "Announcement posted: $url"
+          echo "## Announcement posted" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "$url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release
 
+# Stable tags trigger .github/workflows/release-announcement.yml,
+# which posts a GitHub Discussion in the Announcements category
+# after this workflow publishes. Pre-releases are skipped there.
+# See #51.
+
 on:
   workflow_dispatch:
     inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Stable releases now auto-post an announcement to the GitHub Discussions Announcements category via `.github/workflows/release-announcement.yml`. The workflow triggers on `release: published`, skips pre-releases and drafts, builds the body from the release notes plus a tag-pinned footer template at `.github/DISCUSSION_ANNOUNCEMENT_FOOTER.md`, and authenticates with `GITHUB_TOKEN`. Governance test `TestGovernance_ReleaseAnnouncementWorkflow` pins the trigger, the prerelease/draft filter, the `discussions: write` + `contents: read` permissions, the Announcements category id, and the footer-template reference. ([#51](https://github.com/axonops/mask/issues/51))
+
 ## [1.0.1] — 2026-05-15
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,6 +311,7 @@ The release process is:
 1. Update `CHANGELOG.md` and any version references in a PR to `main`.
 2. After merge, trigger the `Release` workflow via `workflow_dispatch` with the target tag, OR publish a GitHub Release.
 3. CI validates the quality gate, creates the tag, and runs GoReleaser.
+4. On a stable (non-prerelease) tag, `.github/workflows/release-announcement.yml` posts an announcement to the GitHub Discussions Announcements category automatically — the release notes that GoReleaser populated, plus an install-and-docs footer rendered from `.github/DISCUSSION_ANNOUNCEMENT_FOOTER.md` with the tag substituted in. Pre-releases (`-rc`, `-beta`) and drafts are skipped.
 
 Any local tagging attempt is a policy violation. The `devops` review agent treats local tagging in workflows or docs as a BLOCKING issue.
 

--- a/governance_test.go
+++ b/governance_test.go
@@ -310,6 +310,7 @@ func TestGovernance_WorkflowsLeastPrivilegeBaseline(t *testing.T) {
 		".github/workflows/cla.yml",
 		".github/workflows/contributors.yml",
 		".github/workflows/dependabot-automerge.yml",
+		".github/workflows/release-announcement.yml",
 		".github/workflows/release.yml",
 		".github/workflows/scorecard.yml",
 	}
@@ -465,4 +466,55 @@ func TestGovernance_ReleaseAttestations(t *testing.T) {
 		"SECURITY.md must document the gh attestation verify path under '## Verifying a release'")
 	assert.Contains(t, string(security), "gh attestation verify",
 		"SECURITY.md must include the gh attestation verify command")
+}
+
+// TestGovernance_ReleaseAnnouncementWorkflow pins the contract on
+// .github/workflows/release-announcement.yml (#51). The workflow must
+// trigger on `release: published`, skip prereleases and drafts,
+// declare `discussions: write` and `contents: read`, reference the
+// Announcements category id, and read the footer template from
+// .github/DISCUSSION_ANNOUNCEMENT_FOOTER.md.
+func TestGovernance_ReleaseAnnouncementWorkflow(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile(".github/workflows/release-announcement.yml")
+	require.NoError(t, err, ".github/workflows/release-announcement.yml must exist")
+	var v any
+	require.NoError(t, yaml.Unmarshal(body, &v), "release-announcement.yml must be valid YAML")
+	s := string(body)
+
+	assert.Regexp(t, regexp.MustCompile(`(?s)on:\s*\n\s*release:\s*\n\s*types:\s*\[\s*published\s*\]`), s,
+		"workflow must trigger on release: { types: [published] }")
+	assert.Contains(t, s, "github.event.release.prerelease == false",
+		"workflow must skip prereleases")
+	assert.Contains(t, s, "github.event.release.draft == false",
+		"workflow must skip drafts")
+	assert.Contains(t, s, "discussions: write",
+		"workflow must declare discussions: write permission")
+	assert.Contains(t, s, "contents: read",
+		"workflow must declare contents: read permission")
+	assert.Contains(t, s, "DIC_kwDOSFydIc4C7L1u",
+		"workflow must reference the Announcements category id")
+	assert.Contains(t, s, ".github/DISCUSSION_ANNOUNCEMENT_FOOTER.md",
+		"workflow must read the footer template")
+	assert.Contains(t, s, "createDiscussion",
+		"workflow must call the createDiscussion GraphQL mutation")
+
+	footer, err := os.ReadFile(".github/DISCUSSION_ANNOUNCEMENT_FOOTER.md")
+	require.NoError(t, err, ".github/DISCUSSION_ANNOUNCEMENT_FOOTER.md must exist")
+	fs := string(footer)
+	assert.Contains(t, fs, "go get github.com/axonops/mask@<tag>",
+		"footer must contain the version-pinned install command with <tag> placeholder")
+	assert.Contains(t, fs, "pkg.go.dev/github.com/axonops/mask@<tag>",
+		"footer must contain the version-pinned pkg.go.dev link with <tag> placeholder")
+	assert.NotContains(t, fs, "@latest",
+		"footer must not embed floating @latest links — announcements are version-specific")
+
+	for _, fx := range []string{
+		".github/test-fixtures/release-payload-stable.json",
+		".github/test-fixtures/release-payload-prerelease.json",
+		".github/test-fixtures/release-payload-draft.json",
+	} {
+		_, err := os.Stat(fx)
+		assert.NoErrorf(t, err, "test fixture %s must exist", fx)
+	}
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1018,6 +1018,7 @@ The release process is:
 1. Update `CHANGELOG.md` and any version references in a PR to `main`.
 2. After merge, trigger the `Release` workflow via `workflow_dispatch` with the target tag, OR publish a GitHub Release.
 3. CI validates the quality gate, creates the tag, and runs GoReleaser.
+4. On a stable (non-prerelease) tag, `.github/workflows/release-announcement.yml` posts an announcement to the GitHub Discussions Announcements category automatically — the release notes that GoReleaser populated, plus an install-and-docs footer rendered from `.github/DISCUSSION_ANNOUNCEMENT_FOOTER.md` with the tag substituted in. Pre-releases (`-rc`, `-beta`) and drafts are skipped.
 
 Any local tagging attempt is a policy violation. The `devops` review agent treats local tagging in workflows or docs as a BLOCKING issue.
 


### PR DESCRIPTION
Adds .github/workflows/release-announcement.yml — triggers on release: published, skips prereleases/drafts, posts to Announcements category via createDiscussion GraphQL with a tag-pinned footer rendered from .github/DISCUSSION_ANNOUNCEMENT_FOOTER.md. Governance test pins the contract; three fixture payloads cover stable/prerelease/draft. Closes #51.