### PR TITLE
docs(readme): refresh status badge, thread-safety, security pointer for v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   [![Go Reference](https://pkg.go.dev/badge/github.com/axonops/mask.svg)](https://pkg.go.dev/github.com/axonops/mask)
   [![Go Report Card](https://goreportcard.com/badge/github.com/axonops/mask)](https://goreportcard.com/report/github.com/axonops/mask)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
-  ![Status](https://img.shields.io/badge/status-pre--release-orange)
+  ![Status](https://img.shields.io/badge/status-stable%20v1.0.1-brightgreen)
 
   [🚀 Quick Start](#-quick-start) | [✨ Features](#-key-features) | [📚 Built-in Rules](#-built-in-rules) | [🛠 Primitives](#-utility-primitives) | [📖 Docs](./docs/) | [📡 API Reference](https://pkg.go.dev/github.com/axonops/mask)
 </div>
@@ -261,6 +261,8 @@ _ = mask.Register("employee_id", mask.KeepFirstNFunc(9)) // factory
 
 Violating this contract is a data race and will be reported by the Go race detector (`go test -race`). The library does NOT `defer recover()` around custom `RuleFunc` calls — a panic in a custom rule propagates out of `Apply`, by design. Custom rules MUST NOT panic; treat a panic as a programmer error and fix it at source.
 
+As of `v1.0.1`, the package-level registry's lazy initialisation is also safe under concurrent first-call: `Apply` and `HasRule` / `Rules` / `Describe` on a zero-value or never-touched `Masker` from many goroutines simultaneously no longer race against the built-in registrar. Previously a parallel first-caller could observe the registry between the empty-map publish and the built-in registration, falling through to `[REDACTED]` for every rule. Regression tests `TestZeroValueMasker_ParallelFirstApply` and `TestZeroValueMasker_ParallelFirstHasRule` pin the fix.
+
 ```go
 // Correct — register once at init time.
 func init() {
@@ -399,6 +401,8 @@ Before opening your first pull request:
 ## 🔐 Security
 
 See [SECURITY.md](./SECURITY.md) for the threat model, salt-rotation policy, and coordinated disclosure procedure. Security-sensitive issues should be reported privately per that document.
+
+Releases are signed with SLSA/Sigstore build-provenance attestations — verify with `gh attestation verify <artefact> --owner axonops`. See [SECURITY.md §Verifying a release](./SECURITY.md#verifying-a-release).
 
 ## 📄 Licence
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -179,7 +179,7 @@ Full catalogue: runtime via `mask.Rules()` and `mask.Describe(name)`; static ref
   [![Go Reference](https://pkg.go.dev/badge/github.com/axonops/mask.svg)](https://pkg.go.dev/github.com/axonops/mask)
   [![Go Report Card](https://goreportcard.com/badge/github.com/axonops/mask)](https://goreportcard.com/report/github.com/axonops/mask)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
-  ![Status](https://img.shields.io/badge/status-pre--release-orange)
+  ![Status](https://img.shields.io/badge/status-stable%20v1.0.1-brightgreen)
 
   [🚀 Quick Start](#-quick-start) | [✨ Features](#-key-features) | [📚 Built-in Rules](#-built-in-rules) | [🛠 Primitives](#-utility-primitives) | [📖 Docs](./docs/) | [📡 API Reference](https://pkg.go.dev/github.com/axonops/mask)
 </div>
@@ -430,6 +430,8 @@ _ = mask.Register("employee_id", mask.KeepFirstNFunc(9)) // factory
 
 Violating this contract is a data race and will be reported by the Go race detector (`go test -race`). The library does NOT `defer recover()` around custom `RuleFunc` calls — a panic in a custom rule propagates out of `Apply`, by design. Custom rules MUST NOT panic; treat a panic as a programmer error and fix it at source.
 
+As of `v1.0.1`, the package-level registry's lazy initialisation is also safe under concurrent first-call: `Apply` and `HasRule` / `Rules` / `Describe` on a zero-value or never-touched `Masker` from many goroutines simultaneously no longer race against the built-in registrar. Previously a parallel first-caller could observe the registry between the empty-map publish and the built-in registration, falling through to `[REDACTED]` for every rule. Regression tests `TestZeroValueMasker_ParallelFirstApply` and `TestZeroValueMasker_ParallelFirstHasRule` pin the fix.
+
 ```go
 // Correct — register once at init time.
 func init() {
@@ -568,6 +570,8 @@ Before opening your first pull request:
 ## 🔐 Security
 
 See [SECURITY.md](./SECURITY.md) for the threat model, salt-rotation policy, and coordinated disclosure procedure. Security-sensitive issues should be reported privately per that document.
+
+Releases are signed with SLSA/Sigstore build-provenance attestations — verify with `gh attestation verify <artefact> --owner axonops`. See [SECURITY.md §Verifying a release](./SECURITY.md#verifying-a-release).
 
 ## 📄 Licence
 

--- a/readme_shop_front_test.go
+++ b/readme_shop_front_test.go
@@ -118,7 +118,7 @@ var expectedBadgeURLFragments = []string{
 	"pkg.go.dev/badge/github.com/axonops/mask",
 	"goreportcard.com/badge/github.com/axonops/mask",
 	"License-Apache",
-	"status-pre--release",
+	"status-stable",
 }
 
 // TestReadme_BadgeMarkdownReferencesExpectedURLs asserts the README


### PR DESCRIPTION
Post-v1.0.1 cosmetic fixes flagged by user-guide review. Docs-only — admin-merge per project policy. Refs #54, #53.